### PR TITLE
[공통컴포넌트] 모달창 구현

### DIFF
--- a/src/components/common/Button/Cta/medium/BtnMedium.style.ts
+++ b/src/components/common/Button/Cta/medium/BtnMedium.style.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const Wrapper = styled.button`
   ${({ theme: { mixin } }) => mixin.flexCenter({})}
 
-  width: 30.3rem;
+  /* width: 30.3rem; */
   height: 5.2rem;
   padding: 1.5rem 0rem 1.6rem 0rem;
   border-radius: 2.6rem;
@@ -11,9 +11,4 @@ export const Wrapper = styled.button`
   background-color: ${({ theme: { colors } }) => colors.black};
   color: ${({ theme: { colors } }) => colors.white};
   ${({ theme: { fonts } }) => fonts.body_09};
-
-  &:focus {
-    background-color: ${({ theme: { colors } }) => colors.white};
-    color: ${({ theme: { colors } }) => colors.black};
-  }
 `;

--- a/src/components/common/Modal/Modal.style.ts
+++ b/src/components/common/Modal/Modal.style.ts
@@ -6,22 +6,24 @@ export const Overlay = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.5); /* 어두운 색상으로 설정 */
-  z-index: 999; /* 모달보다 낮은 z-index */
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 999;
 `;
 
 export const ModalWrapper = styled.div`
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   display: flex;
   justify-content: flex-end;
   align-items: center;
   flex-direction: column;
+  position: fixed;
+
   width: 283px;
   height: 195px;
   padding: 43px 35px 20px 35px;
+
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   border-radius: 12px;
   gap: 28px;
   flex-shrink: 0;

--- a/src/components/common/Modal/Modal.style.ts
+++ b/src/components/common/Modal/Modal.style.ts
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+export const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5); /* 어두운 색상으로 설정 */
+  z-index: 999; /* 모달보다 낮은 z-index */
+`;
+
+export const ModalWrapper = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  flex-direction: column;
+  width: 283px;
+  height: 195px;
+  padding: 43px 35px 20px 35px;
+  border-radius: 12px;
+  gap: 28px;
+  flex-shrink: 0;
+  background-color: white;
+  z-index: 1000;
+`;
+
+export const ModalContent = styled.div`
+  text-align: center;
+  ${({ theme }) => theme.fonts.body_03};
+`;

--- a/src/components/common/Modal/Modal.style.ts
+++ b/src/components/common/Modal/Modal.style.ts
@@ -17,15 +17,15 @@ export const ModalWrapper = styled.div`
   flex-direction: column;
   position: fixed;
 
-  width: 283px;
-  height: 195px;
-  padding: 43px 35px 20px 35px;
+  width: 28.3rem;
+  height: 19.5rem;
+  padding: 4.3rem 3.5rem 2rem 3.5rem;
 
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
   border-radius: 12px;
-  gap: 28px;
+  gap: 2.8rem;
   flex-shrink: 0;
   background-color: white;
   z-index: 1000;

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import * as S from './Modal.style';
+import BtnMedium from '../Button/Cta/medium/BtnMedium';
+
+interface ModalProps {
+  children: React.ReactNode;
+}
+
+const Modal: React.FC<ModalProps> = ({ children }) => {
+  return (
+    <>
+      <S.Overlay />
+      <S.ModalWrapper>
+        <S.ModalContent>{children}</S.ModalContent>
+        <BtnMedium customStyle={{ width: '21.3rem' }}>확인</BtnMedium>
+      </S.ModalWrapper>
+    </>
+  );
+};
+
+export default Modal;

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -7,7 +7,7 @@ interface ModalProps {
   onConfirmClick?: () => void; // 클릭 이벤트 함수를 받을 수 있는 프롭 추가
 }
 
-const Modal: React.FC<ModalProps> = ({ children, onConfirmClick }) => {
+const Modal = ({ children, onConfirmClick }: ModalProps) => {
   return (
     <>
       <S.Overlay />

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -4,15 +4,18 @@ import BtnMedium from '../Button/Cta/medium/BtnMedium';
 
 interface ModalProps {
   children: React.ReactNode;
+  onConfirmClick?: () => void; // 클릭 이벤트 함수를 받을 수 있는 프롭 추가
 }
 
-const Modal: React.FC<ModalProps> = ({ children }) => {
+const Modal: React.FC<ModalProps> = ({ children, onConfirmClick }) => {
   return (
     <>
       <S.Overlay />
       <S.ModalWrapper>
         <S.ModalContent>{children}</S.ModalContent>
-        <BtnMedium customStyle={{ width: '21.3rem' }}>확인</BtnMedium>
+        <BtnMedium customStyle={{ width: '21.3rem' }} onClick={onConfirmClick}>
+          확인
+        </BtnMedium>
       </S.ModalWrapper>
     </>
   );


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #76 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] 모달창 공통 컴포넌트 구현
- [x] 모달창에 함수도 전달 가능입니다


## Need Review
- 사용법 알려드릴게용! 아래 코드와 같이 <Modal> 사이엔 컴포넌트 텍스트가 들어가면 되고 띄어쓰기 <br/>태그로 분리시킬수 있습니다.
- 함수 같은 경우도 전달하면 버튼 클릭시 잘 동작하는 것을 확인할 수 있었습니다. 다만 함수 전달 로직이이제 컴포넌트에서 함수 생성 -> 공통모달에 전달 -> 공통모달에서 또 공통 버튼에 함수 전달 이여가지고 이게 최선인지는 더 고민해보고 리팩토링 해볼게요! 감사합니다
<img width="478" alt="스크린샷 2024-01-11 오전 3 28 10" src="https://github.com/SWEET-DEVELOPERS/sweet-client/assets/104339899/e27ea273-1385-4811-80a9-cce9ace3fa9b">

<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->



## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
<img width="552" alt="스크린샷 2024-01-11 오전 3 33 12" src="https://github.com/SWEET-DEVELOPERS/sweet-client/assets/104339899/34694d91-581d-4a08-ba30-b17a7be44816">



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
