### PR TITLE
[토너먼트] 다음 버튼 로직 구현 및 이미지 불러오기

### DIFF
--- a/src/components/TournamentNew/TournamentFlow/TournamentCard/TournamentCard.tsx
+++ b/src/components/TournamentNew/TournamentFlow/TournamentCard/TournamentCard.tsx
@@ -9,8 +9,7 @@ interface TournamentCardProps {
   onClick: () => void;
   selected: boolean;
 }
-
-const TournamentCard: React.FC<TournamentCardProps> = ({ item, onClick, selected }) => {
+const TournamentCard = ({ item, onClick, selected }: TournamentCardProps) => {
   const handleClick = () => {
     onClick();
   };

--- a/src/components/TournamentNew/TournamentFlow/TournamentCard/TournamentCard.tsx
+++ b/src/components/TournamentNew/TournamentFlow/TournamentCard/TournamentCard.tsx
@@ -1,5 +1,4 @@
 import * as S from './TournamentCard.style';
-import example from '../../../../assets/img/img.png';
 import { IcExternalGray, Logo } from '../../../../assets/svg';
 import PriceTag from '../../../common/title/Price/PriceTag';
 import { GiftData } from '../../../../core/mockupData';
@@ -12,6 +11,7 @@ interface TournamentCardProps {
 const TournamentCard = ({ item, onClick, selected }: TournamentCardProps) => {
   const handleClick = () => {
     onClick();
+    selected = !selected;
   };
 
   return (
@@ -21,7 +21,7 @@ const TournamentCard = ({ item, onClick, selected }: TournamentCardProps) => {
           <Logo />
         </S.SelectWrapper>
         <S.TournamentImgWrapper>
-          <img src={example} alt={item.name} />
+          <img src={item.imageUrl} alt={item.name} />
         </S.TournamentImgWrapper>
 
         <S.ItemInfo>

--- a/src/components/TournamentNew/TournamentFlow/TournamentFlowContainer.tsx
+++ b/src/components/TournamentNew/TournamentFlow/TournamentFlowContainer.tsx
@@ -41,6 +41,7 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
 
   const clickSelect = (item: GiftData) => () => {
     setClickSelect([item]);
+    setSelected(true);
   };
 
   //토너먼트 라운딩 로직 함수
@@ -82,7 +83,7 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
       setCurrentIndex((prevIndex) => prevIndex + 1);
       console.log('변햇다!');
     }
-    setSelected(true);
+    setSelected(false);
   };
 
   console.log('dma??', firstItems);
@@ -110,7 +111,7 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
                 key={displayitem.name}
                 item={displayitem}
                 onClick={clickSelect(displayitem)}
-                selected={true}
+                selected={isSelected}
               />
             ))}
           </S.TournamentCardWrapper>

--- a/src/components/TournamentNew/TournamentFlow/TournamentFlowContainer.tsx
+++ b/src/components/TournamentNew/TournamentFlow/TournamentFlowContainer.tsx
@@ -16,6 +16,7 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
   // 보여질 아이템
   const [displays, setDisplays] = useState<GiftData[]>([]);
   //선택된 아이템 저장
+
   const [selectedItem, setSelectedItem] = useState<GiftData | null>(null);
   //post 요청을 위한 state
   const [firstItems, setFirstItems] = useState<GiftData[]>([]);
@@ -27,6 +28,9 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
   const [roundIndex, setRoundIndex] = useState<number>(1);
   // 토너먼트 결과화면으로 넘어가게 해주는
   const [showTournamentResult, setShowTournamentResult] = useState(false);
+  const [isSelected, setSelected] = useState(false);
+
+  const [isClickSelect, setClickSelect] = useState<GiftData[]>([]);
 
   //전체 아이템 memberData 랜덤 섞어주기
   useEffect(() => {
@@ -35,11 +39,14 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
     setDisplays([memberData[0], memberData[1]]);
   }, [memberData]);
 
+  const clickSelect = (item: GiftData) => () => {
+    setClickSelect([item]);
+  };
+
   //토너먼트 라운딩 로직 함수
   const clickHandler = (item: GiftData) => () => {
     if (itemPick.length <= 2) {
       if (winners.length === 0) {
-        //위너가 1이 되니까 ,, 요기에 못들어가네
         setDisplays([item]);
         setSelectedItem(item);
         console.log('결과?=:', itemPick); //결승 두개 아이템
@@ -64,7 +71,6 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
         setitemPick([...itemPick.slice(2)]);
       } else {
         let updateditem = [...winners, item, itemPick[2]];
-
         setitemPick([...updateditem]);
         setDisplays([updateditem[0], updateditem[1]]);
         setRoundIndex((roundIndex) => roundIndex + 1);
@@ -76,13 +82,12 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
       setCurrentIndex((prevIndex) => prevIndex + 1);
       console.log('변햇다!');
     }
+    setSelected(true);
   };
 
-  console.log('???', itemPick);
   console.log('dma??', firstItems);
   console.log('dma?????', secondItems);
 
-  const footerClickHandler = () => {};
   return (
     <>
       {showTournamentResult ? (
@@ -100,11 +105,16 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
             totalRounds={memberData.length}
           />
           <S.TournamentCardWrapper>
-            {displays.map((d) => (
-              <TournamentCard key={d.name} item={d} onClick={clickHandler(d)} selected={true} />
+            {displays.map((displayitem) => (
+              <TournamentCard
+                key={displayitem.name}
+                item={displayitem}
+                onClick={clickSelect(displayitem)}
+                selected={true}
+              />
             ))}
           </S.TournamentCardWrapper>
-          <TournamentFooter onNextClick={footerClickHandler} disabled={false} />
+          <TournamentFooter onNextClick={clickHandler(isClickSelect[0])} disabled={false} />
         </S.TournamentFlowContainerWrapper>
       )}
     </>

--- a/src/components/TournamentNew/TournamentFlow/TournamentFlowContainer.tsx
+++ b/src/components/TournamentNew/TournamentFlow/TournamentFlowContainer.tsx
@@ -28,7 +28,7 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
   const [roundIndex, setRoundIndex] = useState<number>(1);
   // 토너먼트 결과화면으로 넘어가게 해주는
   const [showTournamentResult, setShowTournamentResult] = useState(false);
-  const [isSelected, setSelected] = useState(false);
+  const [isSelected, setSelected] = useState<GiftData | null>(null);
 
   const [isClickSelect, setClickSelect] = useState<GiftData[]>([]);
 
@@ -41,7 +41,7 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
 
   const clickSelect = (item: GiftData) => () => {
     setClickSelect([item]);
-    setSelected(true);
+    setSelected(item);
   };
 
   //토너먼트 라운딩 로직 함수
@@ -83,11 +83,8 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
       setCurrentIndex((prevIndex) => prevIndex + 1);
       console.log('변햇다!');
     }
-    setSelected(false);
+    setSelected(null);
   };
-
-  console.log('dma??', firstItems);
-  console.log('dma?????', secondItems);
 
   return (
     <>
@@ -111,7 +108,7 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
                 key={displayitem.name}
                 item={displayitem}
                 onClick={clickSelect(displayitem)}
-                selected={isSelected}
+                selected={isSelected === displayitem}
               />
             ))}
           </S.TournamentCardWrapper>

--- a/src/components/TournamentNew/TournamentFlow/TournamentFooter/TournamentFooter.style.ts
+++ b/src/components/TournamentNew/TournamentFlow/TournamentFooter/TournamentFooter.style.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const TournamentFooterWrapper = styled.footer`
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   position: absolute;
   align-items: center;
 

--- a/src/components/TournamentNew/TournamentFlow/TournamentFooter/TournamentFooter.tsx
+++ b/src/components/TournamentNew/TournamentFlow/TournamentFooter/TournamentFooter.tsx
@@ -1,4 +1,3 @@
-import { IcLeft } from '../../../../assets/svg';
 import BtnNext from '../../../common/Button/Next/BtnNext';
 import * as S from './TournamentFooter.style';
 
@@ -11,10 +10,6 @@ const TournamentFooter = ({ onNextClick }: TournamentFooterProps) => {
   return (
     <>
       <S.TournamentFooterWrapper>
-        <S.Btnpre>
-          <IcLeft style={{ width: '2.4rem', height: '2.4rem' }} />
-          이전
-        </S.Btnpre>
         <BtnNext onClick={onNextClick}>다음</BtnNext>
       </S.TournamentFooterWrapper>
     </>

--- a/src/components/TournamentNew/TournamentResult/TournamentResultCard/TournamentResultCard.tsx
+++ b/src/components/TournamentNew/TournamentResult/TournamentResultCard/TournamentResultCard.tsx
@@ -1,4 +1,3 @@
-import exampleItemImg from '../../../../assets/img/Rectangle.png';
 import { GiftData } from '../../../../core/mockupData';
 import PriceTag from '../../../common/title/Price/PriceTag';
 import * as S from './TournamentResultCard.style';
@@ -14,7 +13,7 @@ const TournamentResultCard: React.FC<TournamentResultCardProps> = ({ item }) => 
     <>
       <S.TournamentCardWrapper>
         <S.TournamentImgWrapper>
-          <img src={exampleItemImg} alt='제품이미지' />
+          <img src={item.imageUrl} alt='제품이미지' />
         </S.TournamentImgWrapper>
 
         <S.ItemInfo>


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #118
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] 카드 클릭 시 넘어가던 구현 다음 버튼으로 넘어가게 selected 처리 했습니다.
- [x] 아이템 이미지 item.imageUrl 대입 
- [x] 다음 버튼눌리면 카테고리 border 속성 변경 


## Need Review
- 제가 바로 useState 지옥입니다. 
- 추후 리팩토링으로 아래 레퍼런스 참고해서 🫨 useReducer 사용해볼까 생각 중입니다. 혹은 `Jotai` 써서 관리해보고 싶습니다.
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->



## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
<img width="375" alt="스크린샷 2024-01-17 오후 9 21 51" src="https://github.com/SWEET-DEVELOPERS/sweet-client/assets/104339899/6fc3f952-7dbf-4546-86f7-e30e0a5f5b2f">



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
[useState 지옥에서 벗어나기](https://velog.io/@eunbinn/a-cure-for-react-useState-hell)