### PR TITLE
[토너먼트] 리프레쉬 아이콘 작동 및 스타일 수정

### DIFF
--- a/src/components/TournamentNew/TournamentFlow/TournamentFlowContainer.tsx
+++ b/src/components/TournamentNew/TournamentFlow/TournamentFlowContainer.tsx
@@ -86,6 +86,12 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
     setSelected(null);
   };
 
+  const refresh = (): void => {
+    const shuffledArray = [...itemPick].sort(() => Math.random() - 0.5);
+    setitemPick(shuffledArray);
+    setDisplays([shuffledArray[0], shuffledArray[1]]);
+  };
+
   return (
     <>
       {showTournamentResult ? (
@@ -101,6 +107,7 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
             rounds={roundIndex}
             currentIndex={currentIndex}
             totalRounds={memberData.length}
+            onClick={refresh}
           />
           <S.TournamentCardWrapper>
             {displays.map((displayitem) => (

--- a/src/components/TournamentNew/TournamentFlow/TournamentTitle/TournamentTitle.tsx
+++ b/src/components/TournamentNew/TournamentFlow/TournamentTitle/TournamentTitle.tsx
@@ -5,10 +5,11 @@ interface TournamentTitleProps {
   rounds: number;
   currentIndex: number;
   totalRounds: number;
+  onClick: () => void;
 }
 
-const TournamentTitle = ({ rounds, currentIndex, totalRounds }: TournamentTitleProps) => {
-  const round = currentIndex; // Adjust the index to start from 1
+const TournamentTitle = ({ rounds, currentIndex, totalRounds, onClick }: TournamentTitleProps) => {
+  const round = currentIndex; 
   return (
     <>
       {/* 라운드 컴포넌트 */}
@@ -18,7 +19,7 @@ const TournamentTitle = ({ rounds, currentIndex, totalRounds }: TournamentTitleP
       </S.SetCount>
       {/* 세트 수 현재 상황 */}
       <S.RefreshWrapper>
-        <IcRefreshGray />
+        <IcRefreshGray onClick={onClick} />
       </S.RefreshWrapper>
     </>
   );

--- a/src/components/TournamentNew/TournamentFlow/TournamentTitle/TournamernTitle.style.ts
+++ b/src/components/TournamentNew/TournamentFlow/TournamentTitle/TournamernTitle.style.ts
@@ -16,8 +16,11 @@ export const SetCount = styled.p`
 `;
 
 export const RefreshWrapper = styled.div`
+  position: relative;
   display: flex;
   justify-content: flex-end;
 
   width: 2.4rem;
+  margin-bottom: 2rem;
+  left: 86%;
 `;

--- a/src/types/tournament/index.d.ts
+++ b/src/types/tournament/index.d.ts
@@ -3,7 +3,7 @@ export type GiftData = {
   imageUrl: string;
   name: string;
   cost: number;
-  url: string;
+  url?: string;
 };
 
 export type GiftRankingData = {


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #174 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] 리프레쉬 무작위로 섞여집니다. 
- [x] 결승이나 라운드 끝일 땐 남은 아이템이 없으니 섞이지 않습니다. 
- [x] 리프레쉬 아이콘 위치 수정했습니다.


## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->



## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

<img width="400" alt="스크린샷 2024-01-18 오전 10 30 40" src="https://github.com/SWEET-DEVELOPERS/sweet-client/assets/104339899/9eab4f56-4a26-40d0-92e3-98cf44fd19fb">


## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
