### PR TITLE
[토너먼트] 다음버튼 활성화, 타이머 세팅, 다시하기 버튼 구현 

### DIFF
--- a/src/components/TournamentNew/TournamentFlow/TournamentFlowContainer.tsx
+++ b/src/components/TournamentNew/TournamentFlow/TournamentFlowContainer.tsx
@@ -29,7 +29,7 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
   // 토너먼트 결과화면으로 넘어가게 해주는
   const [showTournamentResult, setShowTournamentResult] = useState(false);
   const [isSelected, setSelected] = useState<GiftData | null>(null);
-
+  const [disabled, setDisabled] = useState(false);
   const [isClickSelect, setClickSelect] = useState<GiftData[]>([]);
 
   //전체 아이템 memberData 랜덤 섞어주기
@@ -42,6 +42,7 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
   const clickSelect = (item: GiftData) => () => {
     setClickSelect([item]);
     setSelected(item);
+    setDisabled(true);
   };
 
   //토너먼트 라운딩 로직 함수
@@ -84,6 +85,7 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
       console.log('변햇다!');
     }
     setSelected(null);
+    setDisabled(false);
   };
 
   const refresh = (): void => {
@@ -119,7 +121,7 @@ const TournamentFlowContainer = ({ memberData }: TournamentProps) => {
               />
             ))}
           </S.TournamentCardWrapper>
-          <TournamentFooter onNextClick={clickHandler(isClickSelect[0])} disabled={false} />
+          <TournamentFooter onNextClick={clickHandler(isClickSelect[0])} disabled={disabled} />
         </S.TournamentFlowContainerWrapper>
       )}
     </>

--- a/src/components/TournamentNew/TournamentFlow/TournamentFooter/TournamentFooter.tsx
+++ b/src/components/TournamentNew/TournamentFlow/TournamentFooter/TournamentFooter.tsx
@@ -6,11 +6,14 @@ interface TournamentFooterProps {
   disabled: boolean;
 }
 
-const TournamentFooter = ({ onNextClick }: TournamentFooterProps) => {
+const TournamentFooter = ({ onNextClick, disabled }: TournamentFooterProps) => {
+  console.log('여기선?', disabled);
   return (
     <>
       <S.TournamentFooterWrapper>
-        <BtnNext onClick={onNextClick}>다음</BtnNext>
+        <BtnNext onClick={onNextClick} disabled={disabled}>
+          다음
+        </BtnNext>
       </S.TournamentFooterWrapper>
     </>
   );

--- a/src/components/TournamentNew/TournamentResult/TournamentResultFooter/TournamentResultFooter.tsx
+++ b/src/components/TournamentNew/TournamentResult/TournamentResultFooter/TournamentResultFooter.tsx
@@ -4,6 +4,10 @@ interface TournamentResultFooterProps {
   onClick?: () => void; // Add the onClick prop
 }
 const TournamentResultFooter: React.FC<TournamentResultFooterProps> = ({ onClick }) => {
+  const handleRetryClick = () => {
+    // Reload the page when "다시하기" button is clicked
+    window.location.reload();
+  };
   return (
     <TournamentResultFooterWrapper>
       <BtnFill
@@ -13,6 +17,7 @@ const TournamentResultFooter: React.FC<TournamentResultFooterProps> = ({ onClick
           color: 'black',
           border: '1px solid #FF2176',
         }}
+        onClick={handleRetryClick}
       >
         다시하기
       </BtnFill>

--- a/src/components/TournamentNew/TournamentResult/TournamentResultUser/TournamentResultUser.tsx
+++ b/src/components/TournamentNew/TournamentResult/TournamentResultUser/TournamentResultUser.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { useCountDown } from '../../../../hooks/useCountDown';
 import { TournamentUser } from '../../../../types/tournament';
 
 interface TournamentResultUserProps {
@@ -9,7 +10,10 @@ const TournamentResultUser = ({ memberData }: TournamentResultUserProps) => {
   console.log('wtf.', memberData);
   const tournamentUserData = memberData || {};
 
-  console.log(memberData.ParticipantsCount);
+  const [days, hours, minutes, seconds] = useCountDown(tournamentUserData.tournamentStartDate);
+  console.log('Countdown:', hours, 'hours', minutes, 'minutes', seconds, 'seconds');
+
+  console.log(days);
 
   return (
     <TournamentResultUserWrapper>
@@ -22,7 +26,8 @@ const TournamentResultUser = ({ memberData }: TournamentResultUserProps) => {
       <TimerWrapper>
         <Timer>종료까지 남은 시간</Timer>
         <TimerCount>
-          {tournamentUserData.tournamentDuration} {tournamentUserData.tournamentStartDate}
+          {hours.toString().padStart(2, '0')}:{minutes.toString().padStart(2, '0')}:
+          {seconds.toString().padStart(2, '0')}
         </TimerCount>
       </TimerWrapper>
     </TournamentResultUserWrapper>

--- a/src/components/TournamentNew/TournamentResult/TournamentResultUser/TournamentResultUser.tsx
+++ b/src/components/TournamentNew/TournamentResult/TournamentResultUser/TournamentResultUser.tsx
@@ -24,7 +24,7 @@ const TournamentResultUser = ({ memberData }: TournamentResultUserProps) => {
         </UserCount>
       </UserWrapper>
       <TimerWrapper>
-        <Timer>종료까지 남은 시간</Timer>
+        <Timer>토너먼트 종료까지</Timer>
         <TimerCount>
           {hours.toString().padStart(2, '0')}:{minutes.toString().padStart(2, '0')}:
           {seconds.toString().padStart(2, '0')}

--- a/src/components/common/Button/Next/BtnNext.tsx
+++ b/src/components/common/Button/Next/BtnNext.tsx
@@ -9,7 +9,7 @@ type BtnNextProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   onClick?: () => void;
 };
 
-const BtnNext = ({ disabled, children, customStyle, onClick }: BtnNextProps) => {
+const BtnNext = ({ disabled, children, onClick }: BtnNextProps) => {
   console.log('disabled:', disabled);
   return (
     <S.Wrapper

--- a/src/components/common/Button/Next/BtnNext.tsx
+++ b/src/components/common/Button/Next/BtnNext.tsx
@@ -10,8 +10,16 @@ type BtnNextProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 };
 
 const BtnNext = ({ disabled, children, customStyle, onClick }: BtnNextProps) => {
+  console.log('disabled:', disabled);
   return (
-    <S.Wrapper style={customStyle} onClick={onClick} disabled={disabled}>
+    <S.Wrapper
+      style={{
+        backgroundColor: disabled ? '#FF2176' : '#EBE9EA',
+        color: '#fff',
+      }}
+      onClick={onClick}
+      disabled={!disabled}
+    >
       {children}
       <IcRight style={{ width: '2.4rem', height: '2.4rem' }} />
     </S.Wrapper>


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #177 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] 다음 버튼 활성화
- [x] 타이머 세팅
- [x] 다시하기 버튼 구현

## Need Review
- 다시하기 버튼 같은 경우, room Id 를 url로 받고 있어서 reload처리 즉, 새로고침 처리 됐을 때 한번 테스트 해야 될 것 같습니다. 
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->



## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->


https://github.com/SWEET-DEVELOPERS/sweet-client/assets/104339899/3cd2f3d0-1273-4cb9-9435-1d2f5633338a



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
