### PR TITLE
[1.5차 QA : 토너먼트] 토너먼트 방 종료 버튼 구현 및 중복 참여자 ui 개선

### DIFF
--- a/src/components/Tournament/Intro/TournamentDeleteButton/TournamentDeleteButton.tsx
+++ b/src/components/Tournament/Intro/TournamentDeleteButton/TournamentDeleteButton.tsx
@@ -5,7 +5,7 @@ interface TournamentStartButtonProps {
   onClick: () => void;
 }
 
-function TournamentDeleteButton({ onClick }: TournamentStartButtonProps) {
+const TournamentDeleteButton = ({ onClick }: TournamentStartButtonProps) => {
   return (
     <S.TournamentStartButtonWrapper>
       <BtnFill
@@ -21,6 +21,6 @@ function TournamentDeleteButton({ onClick }: TournamentStartButtonProps) {
       </BtnFill>
     </S.TournamentStartButtonWrapper>
   );
-}
+};
 
 export default TournamentDeleteButton;

--- a/src/components/Tournament/Intro/TournamentDeleteButton/TournamentDeleteButton.tsx
+++ b/src/components/Tournament/Intro/TournamentDeleteButton/TournamentDeleteButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import BtnFill from '../../../common/Button/Cta/fill/BtnFill';
 import * as S from './TournamentDeleteButton.style';
 
@@ -6,7 +5,7 @@ interface TournamentStartButtonProps {
   onClick: () => void;
 }
 
-const TournamentDeleteButton: React.FC<TournamentStartButtonProps> = ({ onClick }) => {
+function TournamentDeleteButton({ onClick }: TournamentStartButtonProps) {
   return (
     <S.TournamentStartButtonWrapper>
       <BtnFill
@@ -22,6 +21,6 @@ const TournamentDeleteButton: React.FC<TournamentStartButtonProps> = ({ onClick 
       </BtnFill>
     </S.TournamentStartButtonWrapper>
   );
-};
+}
 
 export default TournamentDeleteButton;

--- a/src/components/Tournament/Intro/TournamentIntroContainer.tsx
+++ b/src/components/Tournament/Intro/TournamentIntroContainer.tsx
@@ -14,6 +14,7 @@ import { TournamentResult } from '../TournamentResult/TournamentResult.sytle';
 import { GiftData } from '../../../types/tournament';
 import TournamentDeleteButton from './TournamentDeleteButton/TournamentDeleteButton';
 import { useNavigate } from 'react-router-dom';
+import Modal from '../../common/Modal/Modal';
 
 const TournamentIntroContainer = () => {
   const navigate = useNavigate();
@@ -35,7 +36,13 @@ const TournamentIntroContainer = () => {
 
   if (typeof memberData === 'string') {
     console.log('Error :', memberData);
-    return <TournamentResult />;
+    return (
+      <Modal>
+        선물 토너먼트를 이미 참여하셨습니다!
+        <br />
+        최종 결과까지 조금만 기다려주세요.
+      </Modal>
+    );
   } else if (memberData && memberData.data) {
     tournamentData = memberData.data;
     console.log(tournamentData);

--- a/src/components/Tournament/Intro/TournamentIntroContainer.tsx
+++ b/src/components/Tournament/Intro/TournamentIntroContainer.tsx
@@ -19,18 +19,15 @@ const TournamentIntroContainer = () => {
   const navigate = useNavigate();
   const params = useParams();
   const giftee = params.giftee;
-
   const roomIdString = params.roomId || '';
   const roomId = parseInt(roomIdString || '', 10);
+  const memberData = useGetItem({ roomId: Number(roomId) });
+  let tournamentData: GiftData[] = [];
 
   const { showTournamentContainer, handleStartClick } = useTournament();
-  const memberData = useGetItem({ roomId: Number(roomId) });
-
   const handleClearRoom = () => {
     navigate(`/mypage`);
   };
-
-  let tournamentData: GiftData[] = [];
 
   if (typeof memberData === 'string') {
     console.log('Error :', memberData);

--- a/src/components/Tournament/Intro/TournamentIntroContainer.tsx
+++ b/src/components/Tournament/Intro/TournamentIntroContainer.tsx
@@ -10,7 +10,6 @@ import { TrophyNone } from '../../../assets/svg';
 import { useParams } from 'react-router';
 import Header from '../../common/Header';
 import TournamentNoneText from './TournamentNoneText/TournamentNoneText';
-import { TournamentResult } from '../TournamentResult/TournamentResult.sytle';
 import { GiftData } from '../../../types/tournament';
 import TournamentDeleteButton from './TournamentDeleteButton/TournamentDeleteButton';
 import { useNavigate } from 'react-router-dom';
@@ -26,7 +25,6 @@ const TournamentIntroContainer = () => {
 
   const { showTournamentContainer, handleStartClick } = useTournament();
   const memberData = useGetItem({ roomId: Number(roomId) });
-  console.log(memberData);
 
   const handleClearRoom = () => {
     navigate(`/mypage`);
@@ -38,9 +36,9 @@ const TournamentIntroContainer = () => {
     console.log('Error :', memberData);
     return (
       <Modal>
-        선물 토너먼트를 이미 참여하셨습니다!
+        선물 토너먼트를
         <br />
-        최종 결과까지 조금만 기다려주세요.
+        이미 참여하셨습니다!
       </Modal>
     );
   } else if (memberData && memberData.data) {

--- a/src/components/Tournament/Intro/TournamentIntroContainer.tsx
+++ b/src/components/Tournament/Intro/TournamentIntroContainer.tsx
@@ -13,8 +13,10 @@ import TournamentNoneText from './TournamentNoneText/TournamentNoneText';
 import { TournamentResult } from '../TournamentResult/TournamentResult.sytle';
 import { GiftData } from '../../../types/tournament';
 import TournamentDeleteButton from './TournamentDeleteButton/TournamentDeleteButton';
+import { useNavigate } from 'react-router-dom';
 
 const TournamentIntroContainer = () => {
+  const navigate = useNavigate();
   const params = useParams();
   const giftee = params.giftee;
 
@@ -24,6 +26,10 @@ const TournamentIntroContainer = () => {
   const { showTournamentContainer, handleStartClick } = useTournament();
   const memberData = useGetItem({ roomId: Number(roomId) });
   console.log(memberData);
+
+  const handleClearRoom = () => {
+    navigate(`/mypage`);
+  };
 
   let tournamentData: GiftData[] = [];
 
@@ -49,7 +55,7 @@ const TournamentIntroContainer = () => {
                     <S.TournamentImg>
                       <TrophyNone />
                     </S.TournamentImg>
-                    <TournamentDeleteButton onClick={handleStartClick} />
+                    <TournamentDeleteButton onClick={handleClearRoom} />
                   </>
                 ) : (
                   <>

--- a/src/components/Tournament/Intro/TournamentIntroContainer.tsx
+++ b/src/components/Tournament/Intro/TournamentIntroContainer.tsx
@@ -32,7 +32,7 @@ const TournamentIntroContainer = () => {
   if (typeof memberData === 'string') {
     console.log('Error :', memberData);
     return (
-      <Modal>
+      <Modal onConfirmClick={handleClearRoom}>
         선물 토너먼트를
         <br />
         이미 참여하셨습니다!


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #373 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] 모달창 띄우기
- [x] 페이지 예외 처리


## Need Review
- 토너먼트 중복 참여자일 경우 모달창을 띄웠습니다. 
- 그리고 현재 any 및 string 값으러 에러 판별에 대해서 타입 해결을 하다가 시간이 길어져서 이슈 따로 파겠습니다! 간단히 봐주시면 될 것 같습니다 :) 
<img width="414" alt="스크린샷 2024-02-21 오후 6 23 37" src="https://github.com/SWEET-DEVELOPERS/sweet-client/assets/104339899/3a78e29c-0294-44a1-ab6f-b4a59b3d4328">

>다만 궁금한건,,이제 모달창을 띄우면 그냥 있는 화면 즉, 컴포넌트 위에 모달창을 띄우고 싶은데 지금 return을 해줘야 해서 return으로 state값을 바꾸려했는데 잘 되지 않았습니다 흑흑..! 그래서 그냥 흰화면에 모달창만 뜨고 다시 돌아오는데 좋은 방법이 있을까요? 

- 선물이 0개일 때 선물방 종료하기 버튼 기능 구현했습니다.


## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->


https://github.com/SWEET-DEVELOPERS/sweet-client/assets/104339899/a0544317-62d0-48b1-959e-fbc456981292



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
