### PR TITLE
feat: 모바일에서 카카오 로그인 버튼 안보이는 현상 로직 수정

### DIFF
--- a/src/pages/Participants/ParticipantsView.tsx
+++ b/src/pages/Participants/ParticipantsView.tsx
@@ -82,13 +82,19 @@ const ParticipantsView = () => {
 
   /**@TODO 현재 token값의 유무에 따라 다른 뷰를 보여주는 로직인데,
    * token의 값이 있든 없든 항상 토큰이 있는 값을 보여주고 있음. 처리 필요 */
+
   useEffect(() => {
-    if (localStorage.getItem('EXIT_LOGIN_TOKEN') !== '') {
-      setIsToken(true);
-      console.log('로컬스토리지 확인', localStorage.getItem('EXIT_LOGIN_TOKEN'));
-    } else {
-      console.log('로컬스토리지 ㄴㄴ', localStorage.getItem('EXIT_LOGIN_TOKEN'));
+    if (localStorage.getItem('EXIT_LOGIN_TOKEN') === null) {
       setIsToken(false);
+      console.log('로컬스토리지 확인', localStorage.getItem('EXIT_LOGIN_TOKEN'));
+      console.log('isTOken', isToken);
+    } else {
+      console.log(
+        'else 로컬스토리지 확인(로컬스토리지 있어야함)',
+        localStorage.getItem('EXIT_LOGIN_TOKEN'),
+      );
+      setIsToken(true);
+      console.log('isTOken', isToken);
     }
   }, [isToken]);
 
@@ -131,7 +137,7 @@ const ParticipantsView = () => {
                   <br /> 선물 준비방이 개설됐어요
                 </Title>
               </S.ParticipantsTitleWrapper>
-              {localStorage.getItem('EXIT_LOGIN_TOKEN') ? (
+              {isToken === true ? (
                 <OnBoardingBtn
                   step={6}
                   customStyle={{ marginBottom: '1.6rem' }}
@@ -157,13 +163,14 @@ const ParticipantsView = () => {
       </S.InfoWrapper>
       {/* 수정된 부분 시작 */}
       <S.BtnWrapper>
-        {localStorage.getItem('EXIT_LOGIN_TOKEN') ? (
+        {isToken === true ? (
           <>
             <S.LinkCopyBtn
               onClick={() =>
-                handleCopyToClipboard(
-                  `http://sweetgift.vercel.app/result/${data.data.invitationCode}`,
-                )
+                // handleCopyToClipboard(
+                //   `http://sweetgift.vercel.app/result/${data.data.invitationCode}`,
+                // )
+                handleCopyToClipboard(`http://localhost:5173/result/${data.data.invitationCode}`)
               }
             >
               <IcLink style={{ width: '1.8rem', height: '1.8rem' }} />


### PR DESCRIPTION
useEffect로 isToken을 boolean으로 주고 그에 따른 삼항 연산자로 뷰를 보여주는 로직으로 수정하였습니다.

<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #380 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [ ] 구현이 되었는지 확인을 위한 머지가 한 번 필요할 것 같습니다.


## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

기존에는 localStorage get Item으로 토큰을 들고와 토큰 여부에 따라 다른 뷰를 보여주는 방식으로 구현했었는데요.
이렇게 구현하니 로그인이 되지 않은 사용자가 진입했을 시 모바일에서 카카오 로그인이 보이지 않는 현상이 있습니다. 

따라서 useEffect로 isToken을 boolean으로 판별 후, true일 때와 false일 때로 구분하여 뷰를 보여주는 방식으로 일부 수정하였습니다. 

현재 이 부분을 로컬에서 확인할 수 있는 방법이 없어서, 확인을 위한 머지가 한 번 필요할 것 같습니다. (제발 되라... ㅠ)

yarn dev --host 에서는 모바일에서 화면 진입 시 아래와 같은 화면이 발생하고 있어 확인이 어렵습니다.
![KakaoTalk_Photo_2024-02-22-00-57-43](https://github.com/SWEET-DEVELOPERS/sweet-client/assets/126966681/3773ecad-c1ca-43b0-8c63-a6fcc526934a)

 이와는 다른 방식으로 localhost 5173은 모바일로 들어갈  수 없으니 확인이 힘들기에 배포 페이지에 한 번 적용시켜 봐야 할 것 같습니다!! 



## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

현재까지 확인된 바로는, 웹에서는 잘 작동하고 있습니다!! 지금은 너무 늦었으니 이따 여러분들 일어나시면 그 때 머지 후 모바일로 확인하고 바로 이 부분 다시 작업 들어가겠습니다.
<img width="1470" alt="스크린샷 2024-02-22 오전 12 29 13" src="https://github.com/SWEET-DEVELOPERS/sweet-client/assets/126966681/c4d933d9-bc65-4e74-b792-bbe53e641cc6">



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
