### PR TITLE
[1.5차 QA] 선물홈 스타일 QA 반영, 선물등록 모달창 추가

### DIFF
--- a/src/components/GiftAdd/GiftAddPageLayout/GiftAddPageLayout.tsx
+++ b/src/components/GiftAdd/GiftAddPageLayout/GiftAddPageLayout.tsx
@@ -6,6 +6,8 @@ import GiftAddPageLayoutHeader from './GiftAddPageLayoutHeader';
 import useGetMyGift from '../../../hooks/queries/gift/useGetMyGift';
 import EmptyGiftAddButtonsWrapper from '../GiftAddButtons/EmptyGiftAddButtonsWrapper';
 import useDeleteMyGift from '../../../hooks/queries/gift/useDeleteMyGift';
+import { useState } from 'react';
+import DeleteModal from '../../common/Modal/DeleteModal';
 
 interface GiftAddPageLayoutProps {
   roomId: string;
@@ -16,31 +18,46 @@ interface GiftAddPageLayoutProps {
   setItemNum: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const GiftAddPageLayout = ({
-  targetDate,
-  roomId,
-  setStep,
-  setItemNum,
-}: GiftAddPageLayoutProps) => {
+const GiftAddPageLayout = ({ targetDate, roomId, setStep, setItemNum }: GiftAddPageLayoutProps) => {
   const roomIdNumber = parseInt(roomId);
-  const { data } = useGetMyGift({ roomId: roomIdNumber});
+  const { data } = useGetMyGift({ roomId: roomIdNumber });
   setItemNum(data.data.myGiftDtoList.length);
+
   const parsedRoomId = parseInt(roomId);
   const { mutation } = useDeleteMyGift(parsedRoomId);
 
   const myGiftData = data.data.myGiftDtoList;
   const adPrice = '39,000';
 
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [clickedItem, setClickedItem] = useState<number>();
+  // 모달 확인 클릭 버튼
+  const handleClickDeleteClick = (giftId: number) => {
+    setClickedItem(giftId);
+    setIsModalOpen(true);
+  };
+
   const handleClickAddBtn = () => {
+    console.log('working?');
     setStep(1);
   };
 
-  const handleClickCancelBtn = (giftId: number) => {
+  const handleClickConfirmDeleteBtn = (giftId: number) => {
     mutation.mutate(giftId);
+    setIsModalOpen(false);
   };
 
   return (
     <S.GiftAddPageWrapper>
+      {isModalOpen && (
+        <DeleteModal
+          onClickCancel={() => setIsModalOpen(false)}
+          onClickDelete={handleClickConfirmDeleteBtn}
+          clickedItem={clickedItem}
+        >
+          정말 상품을 삭제하시겠어요?
+        </DeleteModal>
+      )}
       <GiftAddPageLayoutHeader title={'내가 등록한 선물'} />
       <MiniTimer targetDate={targetDate || ''} />
       <S.AddButtonsWrapper>
@@ -48,7 +65,7 @@ const GiftAddPageLayout = ({
           <GiftAddButtonsWrapper
             key={index}
             data={item}
-            onCancelClick={() => handleClickCancelBtn(item.giftId)}
+            onCancelClick={() => handleClickDeleteClick(item.giftId)}
           />
         ))}
         {Array.from({ length: 2 - myGiftData.length }).map((_, index) => (

--- a/src/components/GiftHome/GiftHome2030Gifts/GiftHome2030Gifts.tsx
+++ b/src/components/GiftHome/GiftHome2030Gifts/GiftHome2030Gifts.tsx
@@ -11,7 +11,7 @@ interface GiftHome2030GiftsProps {
 
 export const GiftHome2030Gifts = ({ roomId, data, targetDate }: GiftHome2030GiftsProps) => {
   return (
-    <S.GiftHomeShowcaseWrapper>
+    <S.GiftHomeShowcaseWrapper $isData={data.length > 0}>
       <GiftHomeShowcaseHeader
         targetDate={targetDate}
         roomId={roomId}

--- a/src/components/GiftHome/GiftHomeFriendsGifts/GiftHomeFriendsGifts.tsx
+++ b/src/components/GiftHome/GiftHomeFriendsGifts/GiftHomeFriendsGifts.tsx
@@ -15,7 +15,7 @@ export default function GiftHomeFriendsGifts({
   data,
 }: GiftHomeFriendsGiftsProps) {
   return (
-    <S.GiftHomeShowcaseWrapper>
+    <S.GiftHomeShowcaseWrapper $isData={data.length > 0}>
       <GiftHomeShowcaseHeader
         roomId={roomId}
         targetDate={targetDate}

--- a/src/components/GiftHome/GiftHomeMyGifts/GiftHomeMyGiftsItem.style.ts
+++ b/src/components/GiftHome/GiftHomeMyGifts/GiftHomeMyGiftsItem.style.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const GiftHomeMyGifts = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: 3rem;
+  margin-bottom: 1.2rem;
 
   height: 7rem;
   img {

--- a/src/components/GiftHome/common/GiftHomeShowcase.styled.ts
+++ b/src/components/GiftHome/common/GiftHomeShowcase.styled.ts
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
-export const GiftHomeShowcaseWrapper = styled.section`
+export const GiftHomeShowcaseWrapper = styled.section<{ $isData: boolean }>`
   width: 100%;
-  padding: 0.6rem 0 0.6rem 2rem;
+  padding: ${({ $isData }) => ($isData ? '0.6rem 0 0.6rem 2rem' : '0.6rem 2rem 0.6rem 2rem')};
   margin-bottom: 3.6rem;
 `;
 
@@ -23,7 +23,6 @@ export const NoGiftsWrapper = styled.div`
 export const GiftsWrapper = styled.div`
   width: 36rem;
   height: 22.5rem;
-  /* padding-left: 2rem; */
 
   display: flex;
   column-gap: 0.8rem;

--- a/src/components/GiftHome/common/GiftHomeShowcaseItem.styled.ts
+++ b/src/components/GiftHome/common/GiftHomeShowcaseItem.styled.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const GiftsItemWrapper = styled.div`
   width: 13rem;
-  /* height: 22.5rem; */
+  height: 22.5rem;
 
   display: flex;
   flex-direction: column;

--- a/src/components/common/Modal/DeleteModal.style.ts
+++ b/src/components/common/Modal/DeleteModal.style.ts
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+export const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 999;
+`;
+
+export const DeleteModalWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  flex-direction: column;
+  position: fixed;
+
+  width: 28.3rem;
+  height: 19.3rem;
+  padding: 4.3rem 3.5rem 2rem 3.5rem;
+
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 12px;
+  gap: 2.8rem;
+  flex-shrink: 0;
+  background-color: white;
+  z-index: 1000;
+`;
+
+export const DeleteModalContent = styled.div`
+  text-align: center;
+  ${({ theme }) => theme.fonts.body_03};
+`;
+
+export const BtnWrapper = styled.div`
+  display: flex;
+`;

--- a/src/components/common/Modal/DeleteModal.tsx
+++ b/src/components/common/Modal/DeleteModal.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import * as S from './DeleteModal.style';
+import BtnMedium from '../Button/Cta/medium/BtnMedium';
+import { IcCancel } from '../../../assets/svg';
+
+interface DeleteModalProps {
+  children: React.ReactNode;
+  onClickDelete: (giftId: number) => void;
+  onClickCancel: () => void;
+  clickedItem: number | undefined;
+}
+
+const DeleteModal = ({ children, onClickDelete, onClickCancel, clickedItem }: DeleteModalProps) => {
+  return (
+    <>
+      <S.Overlay />
+      <S.DeleteModalWrapper>
+        <IcCancel style={{ width: '2.4rem', color: 'black' }} onClick={onClickCancel} />
+        <S.DeleteModalContent>{children}</S.DeleteModalContent>
+        <S.BtnWrapper>
+          <BtnMedium
+            customStyle={{
+              width: '12rem',
+              outline: 'none',
+              border: 'none',
+              backgroundColor: 'white',
+              color: 'black',
+            }}
+            onClick={() => (clickedItem ? onClickDelete(clickedItem) : onClickCancel())}
+          >
+            네, 삭제할게요
+          </BtnMedium>
+          <BtnMedium customStyle={{ width: '12rem' }} onClick={onClickCancel}>
+            아니오
+          </BtnMedium>
+        </S.BtnWrapper>
+      </S.DeleteModalWrapper>
+    </>
+  );
+};
+
+export default DeleteModal;

--- a/src/pages/GiftHome/GiftHomeMyGifts/GiftHomeMyGifts.style.ts
+++ b/src/pages/GiftHome/GiftHomeMyGifts/GiftHomeMyGifts.style.ts
@@ -2,8 +2,11 @@ import styled from 'styled-components';
 
 export const GiftHomeMyGiftsWrapper = styled.article`
   width: 100%;
+  margin-bottom: 1.8rem;
 
-  padding: 2rem;
+  padding: 0.6rem 0.5rem 0 2rem;
 `;
 
-export const GiftsWrapper = styled.div``;
+export const GiftsWrapper = styled.div`
+  gap: 1.7rem;
+`;

--- a/src/pages/GiftHomeDetail/GiftHomeDetail.tsx
+++ b/src/pages/GiftHomeDetail/GiftHomeDetail.tsx
@@ -22,7 +22,6 @@ export const GiftHomeDetail = () => {
       <GiftDetailHeader
         title='요즘 2030이 주목하는 선물'
         roomId={roomId || ''}
-        // targetDate={targetDate || ''}
       />
       <MiniTimer targetDate={targetDate?.toString() || ''} />
       <S.GiftHomeDetailWrapper>


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #398
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] 2030 글자 안 잘리게
- [x] 엠티뷰 중앙 정렬
- [x] 선물방 메인 아이템 정렬 맞게
- [x] 선물등록 삭제 모달 추가

## Need Review
- 자잘한 스타일 수정들이라 변경사항 간단하게 확인해주시면 될 것 같습니다:)
## !! 선물등록 삭제 모달 추가
- 실수로 해당 PR에서 선물등록 삭제 모달 추가를 구현했습니다..! 기디 요청에 맞게 선물 삭제 버튼을 누르면 재확인하는 모달을 띄워주었고, 이에 따라 DELETE가 삭제 확인 버튼을 눌렀을 때 작동하도록 수정했습니다.
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->



## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
- 엠티뷰 중앙 정렬
![Screenshot 2024-02-23 at 12 58 55 PM](https://github.com/SWEET-DEVELOPERS/sweet-client/assets/92876819/e1c02126-62ca-4d10-a69c-a6033ff0ca12)
- 2030 글자 안 잘리게 수정
![Screenshot 2024-02-23 at 12 58 59 PM](https://github.com/SWEET-DEVELOPERS/sweet-client/assets/92876819/a0354081-3e41-4cef-bfc8-bdc259453730)
- 선물방 메인 아이템 정렬
![Screenshot 2024-02-23 at 12 59 34 PM](https://github.com/SWEET-DEVELOPERS/sweet-client/assets/92876819/8fac43f1-fbb6-4fb5-94db-1d161577385f)
- 삭제모달 구현(다만 X 아이콘 색상 변경 계속 안 되고 있어서 이 부분은 이따가 다른 모달 추가 구현 시 함께 해결하겠습니다)

https://github.com/SWEET-DEVELOPERS/sweet-client/assets/92876819/1c297185-78c1-4fd3-89d8-d8003d010d69


## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
