### PR TITLE
[1.5차 QA] 중복 모달 추가 및 스크롤 생기는 이슈 해결

### DIFF
--- a/src/components/GiftAdd/AddGiftLayout/AddGiftWithLinkLayout.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/AddGiftWithLinkLayout.tsx
@@ -9,6 +9,7 @@ import { OpenGraphResponseType } from '../../../types/etc';
 import LinkAddHeader from '../AddGiftLink/common/LinkAddHeader/LinkAddHeader';
 import { AddGiftInfo } from '../../../types/gift';
 import useConvertURLtoFile from '../../../hooks/useConvertURLtoFile';
+import DuplicateModal from '../../common/Modal/DuplicateModal';
 
 interface AddGiftWithLinkLayoutProps {
   link: string;
@@ -46,6 +47,8 @@ const AddGiftWithLinkLayout = ({
   const [, setIsImageUploaded] = useState<boolean>(false);
   const [, setPreviewImage] = useState<string | null>(null);
 
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  console.log('ISMODAL', isModalOpen);
   const checkPriceNull = (price: number | null) => {
     if (price === null) {
       return 0;
@@ -76,6 +79,9 @@ const AddGiftWithLinkLayout = ({
 
   return (
     <S.AddGiftWithLinkLayoutWrapper>
+      {isModalOpen && (
+        <DuplicateModal onConfirmClick={() => setIsModalOpen(false)}>중복된 값</DuplicateModal>
+      )}
       <LinkAddHeader
         targetDate={targetDate}
         setStep={setStep}
@@ -116,6 +122,7 @@ const AddGiftWithLinkLayout = ({
         file={file}
         setImageUrl={setImageUrl}
         setIsLoading={setIsLoading}
+        setIsModalOpen={setIsModalOpen}
       />
     </S.AddGiftWithLinkLayoutWrapper>
   );

--- a/src/components/GiftAdd/GiftAddPageLayout/GiftAddPageLayout.tsx
+++ b/src/components/GiftAdd/GiftAddPageLayout/GiftAddPageLayout.tsx
@@ -21,12 +21,14 @@ interface GiftAddPageLayoutProps {
 const GiftAddPageLayout = ({ targetDate, roomId, setStep, setItemNum }: GiftAddPageLayoutProps) => {
   const roomIdNumber = parseInt(roomId);
   const { data } = useGetMyGift({ roomId: roomIdNumber });
-  setItemNum(data.data.myGiftDtoList.length);
+
+  const gifteeName = data.data.gifteeName;
+  setItemNum(data.data.myGiftsResponseDto.myGiftDtoList.length);
 
   const parsedRoomId = parseInt(roomId);
   const { mutation } = useDeleteMyGift(parsedRoomId);
 
-  const myGiftData = data.data.myGiftDtoList;
+  const myGiftData = data.data.myGiftsResponseDto.myGiftDtoList;
   const adPrice = '39,000';
 
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -58,7 +60,7 @@ const GiftAddPageLayout = ({ targetDate, roomId, setStep, setItemNum }: GiftAddP
           정말 상품을 삭제하시겠어요?
         </DeleteModal>
       )}
-      <GiftAddPageLayoutHeader title={'내가 등록한 선물'} />
+      <GiftAddPageLayoutHeader title={'내가 등록한 선물'} giftee={gifteeName} />
       <MiniTimer targetDate={targetDate || ''} />
       <S.AddButtonsWrapper>
         {myGiftData.map((item, index) => (

--- a/src/components/common/MiniTimer/MiniTimer.tsx
+++ b/src/components/common/MiniTimer/MiniTimer.tsx
@@ -9,7 +9,7 @@ interface MiniTimerProps {
 const MiniTimer = ({ targetDate }: MiniTimerProps) => {
   const [days, hours, minutes, seconds] = useCountDown(targetDate);
   // 빌드 에러 해결
-  console.log(days);
+  // console.log(days);
   return (
     <S.MiniTimerWrapper>
       <IcClock

--- a/src/components/common/Modal/DeleteModal.tsx
+++ b/src/components/common/Modal/DeleteModal.tsx
@@ -15,7 +15,10 @@ const DeleteModal = ({ children, onClickDelete, onClickCancel, clickedItem }: De
     <>
       <S.Overlay />
       <S.DeleteModalWrapper>
-        <IcCancel style={{ width: '2.4rem', color: 'black' }} onClick={onClickCancel} />
+        <IcCancel
+          style={{ width: '2.4rem', position: 'absolute', top: '1.6rem', right: '1.6rem' }}
+          onClick={onClickCancel}
+        />
         <S.DeleteModalContent>{children}</S.DeleteModalContent>
         <S.BtnWrapper>
           <BtnMedium

--- a/src/components/common/Modal/DuplicateModal.style.ts
+++ b/src/components/common/Modal/DuplicateModal.style.ts
@@ -10,16 +10,15 @@ export const Overlay = styled.div`
   z-index: 999;
 `;
 
-export const DeleteModalWrapper = styled.div`
+export const DuplicateModalWrapper = styled.div`
   display: flex;
-  justify-content: center;
   justify-content: flex-end;
   align-items: center;
   flex-direction: column;
   position: fixed;
 
   width: 28.3rem;
-  height: 19.3rem;
+  height: 19.5rem;
   padding: 4.3rem 3.5rem 2rem 3.5rem;
 
   top: 50%;
@@ -32,11 +31,7 @@ export const DeleteModalWrapper = styled.div`
   z-index: 1000;
 `;
 
-export const DeleteModalContent = styled.div`
+export const DuplicateModalContent = styled.div`
   text-align: center;
   ${({ theme }) => theme.fonts.body_03};
-`;
-
-export const BtnWrapper = styled.div`
-  display: flex;
 `;

--- a/src/components/common/Modal/DuplicateModal.tsx
+++ b/src/components/common/Modal/DuplicateModal.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import * as S from './DuplicateModal.style';
+import BtnMedium from '../Button/Cta/medium/BtnMedium';
+
+interface DuplicateModalProps {
+  children: React.ReactNode;
+  onConfirmClick?: () => void;
+}
+
+const DuplicateModal = ({ children, onConfirmClick }: DuplicateModalProps) => {
+  return (
+    <>
+      <S.Overlay />
+      <S.DuplicateModalWrapper>
+        <S.DuplicateModalContent>{children}</S.DuplicateModalContent>
+        <BtnMedium customStyle={{ width: '21.3rem' }} onClick={onConfirmClick}>
+          다시 등록하기
+        </BtnMedium>
+      </S.DuplicateModalWrapper>
+    </>
+  );
+};
+
+export default DuplicateModal;

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as S from './Modal.style';
 import BtnMedium from '../Button/Cta/medium/BtnMedium';
+import { IcCancel } from '../../../assets/svg';
 
 interface ModalProps {
   children: React.ReactNode;
@@ -12,6 +13,10 @@ const Modal = ({ children, onConfirmClick }: ModalProps) => {
     <>
       <S.Overlay />
       <S.ModalWrapper>
+        <IcCancel
+          style={{ width: '2.4rem', position: 'absolute', top: '1.6rem', right: '1.6rem' }}
+          onClick={onConfirmClick}
+        />
         <S.ModalContent>{children}</S.ModalContent>
         <BtnMedium customStyle={{ width: '21.3rem' }} onClick={onConfirmClick}>
           확인

--- a/src/context/DuplicateModal/DuplicateModalContext.tsx
+++ b/src/context/DuplicateModal/DuplicateModalContext.tsx
@@ -1,0 +1,36 @@
+import { PropsWithChildren, createContext, useContext, useState } from 'react';
+
+interface DuplicateModalContextType {
+  modalStatus: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+}
+const initialContext: DuplicateModalContextType = {
+  modalStatus: false,
+  openModal: () => {},
+  closeModal: () => {},
+};
+
+const DuplicateModalContext = createContext<DuplicateModalContextType>(initialContext);
+
+export const useDuplicateModalContext = () => useContext(DuplicateModalContext);
+
+export const DuplicateModalProvider = ({ children }: PropsWithChildren) => {
+  const [modalStatus, setModalStatus] = useState(false);
+
+  const openModal = () => {
+    console.log('open modal');
+    setModalStatus(true);
+  };
+
+  const closeModal = () => {
+    console.log('close modal');
+    setModalStatus(false);
+  };
+
+  return (
+    <DuplicateModalContext.Provider value={{ modalStatus, openModal, closeModal }}>
+      {children}
+    </DuplicateModalContext.Provider>
+  );
+};

--- a/src/hooks/queries/gift/usePostGift.tsx
+++ b/src/hooks/queries/gift/usePostGift.tsx
@@ -4,9 +4,19 @@ import { AddGiftInfo, GiftPostRequestType } from '../../../types/gift';
 import { useNavigate } from 'react-router-dom';
 import { MY_GIFT_QUERY_KEY } from './useGetMyGift';
 
-export async function postNewGift(body: GiftPostRequestType) {
-  await post(`/gift`, body);
-}
+export const postNewGift = async (body: GiftPostRequestType) => {
+  try {
+    const response = await post(`/gift`, body);
+    console.log('response data', response.data);
+    return response.data;
+  } catch (error: any) {
+    console.log('확인확인', error.message);
+    if (error.message === '중복된 선물 등록입니다.') {
+      console.log('들어와~', error);
+      throw new Error(`${error}`);
+    }
+  }
+};
 
 export const usePostGift = (
   roomId: number,
@@ -14,6 +24,7 @@ export const usePostGift = (
   setStep: React.Dispatch<React.SetStateAction<number>>,
   updateAddGiftInfo: (newInfo: Partial<AddGiftInfo>) => void,
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>,
+  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>,
 ) => {
   const navigate = useNavigate();
 
@@ -31,6 +42,11 @@ export const usePostGift = (
     },
     onError: (error) => {
       console.log('선물 등록 에러!!', error.message);
+      if (error.message === 'Error: 중복된 선물 등록입니다.') {
+        console.log('잘 들어오고 있닝');
+        setIsModalOpen((prev) => !prev);
+        return error;
+      }
     },
   });
 

--- a/src/pages/GiftHomeDetail/GiftHomeDetail.tsx
+++ b/src/pages/GiftHomeDetail/GiftHomeDetail.tsx
@@ -6,10 +6,8 @@ import GiftHomePriceTag from '../../components/common/GiftHome/Price/GiftHomePri
 import GiftDetailHeader from '../../components/common/GiftDetail/GiftDetailHeader';
 
 export const GiftHomeDetail = () => {
-  // const location = useLocation();
   const params = useParams();
   console.log('params', params);
-  // const searchParams = new URLSearchParams(location.search);
   const roomId = params.roomId;
   console.log('roomId', roomId);
   const targetDate = params.targetDate;

--- a/src/pages/GiftHomeDetail/GiftHomeDetail2030.tsx
+++ b/src/pages/GiftHomeDetail/GiftHomeDetail2030.tsx
@@ -6,14 +6,7 @@ import GiftHomePriceTag from '../../components/common/GiftHome/Price/GiftHomePri
 import GiftDetailHeader from '../../components/common/GiftDetail/GiftDetailHeader';
 
 function GiftHomeDetail() {
-  // const location = useLocation();
-
-  // const searchParams = new URLSearchParams(location.search);
-  // const roomId = searchParams.get('roomId');
-  // console.log('roomId', roomId);
-  // const targetDate = searchParams.get('targetTime');
   const params = useParams();
-  // console.log('params', params);
   const roomId = params.roomId;
 
   const targetDate = params.targetDate;
@@ -22,11 +15,7 @@ function GiftHomeDetail() {
 
   return (
     <S.GiftHomeDetailPageWrapper>
-      <GiftDetailHeader
-        title='요즘 2030이 주목하는 선물'
-        roomId={roomId || ''}
-        // targetDate={targetDate || ''}
-      />
+      <GiftDetailHeader title='요즘 2030이 주목하는 선물' roomId={roomId || ''} />
       <MiniTimer targetDate={targetDate?.toString() || ''} />
       <S.GiftHomeDetailWrapper>
         {data.data.hotProductDtoList.length > 0 ? (

--- a/src/types/gift/index.d.ts
+++ b/src/types/gift/index.d.ts
@@ -6,6 +6,12 @@ export interface GiftPostRequestType {
   imageUrl: string;
 }
 
+export interface GiftPostResponseType {
+  status: number;
+  success?: boolean;
+  message: string;
+}
+
 export interface GiftType {
   giftId: number;
   imageUrl: string;
@@ -13,8 +19,13 @@ export interface GiftType {
   cost: number;
 }
 
-export interface MyGiftsType {
+export interface myGiftsResponseDtoType {
   myGiftDtoList: GiftType[];
+}
+
+export interface MyGiftsType {
+  gifteeName: string;
+  myGiftsResponseDto: myGiftsResponseDtoType;
 }
 export interface AddGiftInfo {
   name: name;


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #409 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] 중복 모달 추가
- [ ] 스크롤 생기는 이슈(인풋창)


## Need Review
### 중복 모달 추가
- `onError`와 `try..catch`로 409 에러가 반환되면 중복에 해당하는 것을 잡아내는 것까지는 완료하였으나, 409 에러 발생시 실행하는 `setIsModalOpen`이 제대로 작동하지 않는 이슈가 해결되지 않아 현재는 409 에러가 발생하면 선물 등록 홈으로 이동하지 않고 해당 화면에 머물도록 되어 있습니다. 정말 이유를 한참 찾고 있는데 같은 것만 봐서 잘 보이지 않는 것 같기도 하고,,, 여러분의 피드백 완전 환영입니다~!!
(`AddGiftWithLinkLayout`,`AddGiftFooter`, `usePostGift` 위주로 확인하시면 됩니다!) 
- 오늘 중복 모달 관련 작업을 시작하게 되어서 하나 남은 인풋 작성 시 키패드가 올라와서 스크롤이 올라가는 이슈는 추후 새로운 최종 QA PR에서 작업하겠습니다!ㅠ
### gifteeName 반영
- 서버쌤께서 추가해주신 gifteeName을 활용해 카운트 다운이 완료되면 토너먼트 뷰로 이동하도록 수정하였습니다.
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->



## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
