### PR TITLE
[시작페이지] 2차 qa 내용 반영입니다 !

### DIFF
--- a/src/assets/svg/IcDown.tsx
+++ b/src/assets/svg/IcDown.tsx
@@ -2,7 +2,7 @@ import type { SVGProps } from 'react';
 const SvgIcDown = (props: SVGProps<SVGSVGElement>) => (
   <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 40 40' {...props}>
     <path
-      stroke='#FF2176'
+      stroke={props.stroke || '#FF2176'}
       strokeLinecap='round'
       strokeLinejoin='round'
       strokeWidth={1.5}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -41,9 +41,9 @@ const Footer = ({ customStyle }: FooterType) => {
         <LongDivider />
         <S.Text>Copyright 2024. Sweet. all rights reserved.</S.Text>
         <S.Icon>
-          <IcInstagram style={{ width: '2.8rem' }} onClick={InstaGram} />
+          <IcInstagram style={{ width: '2.8rem', marginRight: '0.4rem' }} onClick={InstaGram} />
 
-          <IcPalmspring style={{ width: '2.8rem' }} onClick={PamSpring} />
+          <IcPalmspring style={{ width: '2.8rem', marginLeft: '0.5rem' }} onClick={PamSpring} />
         </S.Icon>
       </S.TextWrapper>
     </S.FooterWrapper>

--- a/src/pages/LoginError/LoginError.style.ts
+++ b/src/pages/LoginError/LoginError.style.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { IcKakoLarge } from '../../assets/svg';
+import { IcKakaoSmall } from '../../assets/svg';
 
 export const LoginErrorWrapper = styled.div`
   ${({ theme: { mixin } }) => mixin.flexCenter({})};
@@ -20,7 +20,7 @@ export const SubInfoText = styled.p`
   margin-bottom: 2rem;
 `;
 
-export const KakaoLogin = styled(IcKakoLarge)`
+export const KakaoLogin = styled(IcKakaoSmall)`
   display: inline-flex;
-  padding: 1rem 3.6rem;
+  padding: 0 9.4rem;
 `;

--- a/src/pages/Start/LogoHeader/LogoHeader.style.ts
+++ b/src/pages/Start/LogoHeader/LogoHeader.style.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const LogoHeaderWrapper = styled.div`
-  ${({ theme: { mixin } }) => mixin.flexBox({ justify: 'center' })};
+  ${({ theme: { mixin } }) => mixin.flexBox({ justify: 'center', align: 'center' })};
   position: fixed;
   width: 100%;
   height: 5.6rem;
@@ -13,6 +13,7 @@ export const LogoHeaderWrapper = styled.div`
 export const IconWrapper = styled.div`
   ${({ theme: { mixin } }) => mixin.flexBox({ align: 'center' })};
   width: 37.5rem;
+  height: 100%;
   gap: 21.2rem;
   padding: 0 2rem;
 `;

--- a/src/pages/Start/LogoHeader/LogoHeader.style.ts
+++ b/src/pages/Start/LogoHeader/LogoHeader.style.ts
@@ -20,7 +20,7 @@ export const IconWrapper = styled.div`
 
 export const UserProfileImg = styled.img`
   ${({ theme: { mixin } }) => mixin.flexBox({})};
-  width: 3rem;
-  height: 3rem;
-  border-radius: 9rem;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 99rem;
 `;

--- a/src/pages/Start/Start.style.ts
+++ b/src/pages/Start/Start.style.ts
@@ -10,7 +10,7 @@ import {
 import BtnFill from '../../components/common/Button/Cta/fill/BtnFill';
 
 export const Wrapper = styled.div`
-  width: 37.5rem;
+  width: 100%;
   height: 100vh;
   background-repeat: no-repeat;
   ${({ theme: { mixin } }) => mixin.flexCenter({})};

--- a/src/pages/Start/Start.tsx
+++ b/src/pages/Start/Start.tsx
@@ -25,7 +25,7 @@ const Start = () => {
       <S.Main2 />
       <LottieAnimation
         animation={TournamentAnimation}
-        customStyle={{ position: 'absolute', top: '157.5rem', zIndex: '1' }}
+        customStyle={{ position: 'absolute', top: '160rem', zIndex: '1' }}
       />
       <S.Main3 />
       <StartStepAnimation />

--- a/src/pages/Start/StartAnimation/DownIconAnimation/StartDownIconAnimation.style.ts
+++ b/src/pages/Start/StartAnimation/DownIconAnimation/StartDownIconAnimation.style.ts
@@ -1,13 +1,28 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import { IcDown } from '../../../../assets/svg';
 
 export const DownIconWrapper = styled.div`
-  display: flex;
+  ${({ theme: { mixin } }) => mixin.flexCenter({})};
+  position: relative;
 `;
 
-export const DownIcon = styled(IcDown)`
+const frameInAnimationUp = keyframes`
+  0% {
+    opacity: 1;
+    transform: translateY(0%);
+  }
+
+  100%{
+    opacity: 0;
+    transform: translateY(-100%);
+  }
+`;
+
+export const DownIcon = styled(IcDown)<{ $isVisible: boolean }>`
   position: absolute;
   top: 4rem;
   width: 4rem;
   color: ${({ theme: { colors } }) => colors.G_07};
+  opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)}; /* 스크롤에 따라 투명도 조절 */
+  animation: ${({ $isVisible }) => ($isVisible ? 'none' : frameInAnimationUp)} 2s forwards; /* isVisible에 따라 애니메이션 적용 */
 `;

--- a/src/pages/Start/StartAnimation/DownIconAnimation/StartDownIconAnimation.tsx
+++ b/src/pages/Start/StartAnimation/DownIconAnimation/StartDownIconAnimation.tsx
@@ -1,12 +1,24 @@
-import { ScrollAnimationUpContainer } from '../../../../components/ScrollAnimationContainer/ScrollAnimationContainerUp';
+import { useEffect, useState } from 'react';
 import * as S from './StartDownIconAnimation.style';
 
 const StartDownIconAnimation = () => {
+  const [isTop, setIsTop] = useState(true);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+      setIsTop(scrollTop === 0);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
   return (
     <S.DownIconWrapper>
-      <ScrollAnimationUpContainer>
-        <S.DownIcon />
-      </ScrollAnimationUpContainer>
+      <S.DownIcon $isVisible={isTop} />
     </S.DownIconWrapper>
   );
 };

--- a/src/pages/Start/StartAnimation/GiftAnimation/StartGiftAnimation.style.ts
+++ b/src/pages/Start/StartAnimation/GiftAnimation/StartGiftAnimation.style.ts
@@ -13,7 +13,7 @@ export const ImgWrapper = styled.div`
   }
 `;
 export const TextWrapper = styled.div`
-  ${({ theme: { mixin } }) => mixin.flexCenter};
+  ${({ theme: { mixin } }) => mixin.flexCenter({})};
   position: absolutes;
   margin-top: -11rem;
 


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #432 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] 로그인 실패 시 카카오 로그인 버튼 사이즈 줄이기 
- [x] 토너먼트 애니메이션 아이콘 위치 수정
- [x] 밑으로 내리는 화살표 밑으로 스크롤 시에만 없어지게 하기
- [x] 헤더 스윗 로고가 짤려서 보임 ! 중앙정렬 하기
- [x] 인스타랑 팜스 아이콘 조금 더 멀리 !! figma 확인하기
- [x]  헤더 profileImage 완전한 원형으로 만들기...하아니 이거 원형 아니냐고 충격

## Need Review
- 화살표 밑으로 스크롤 시 없어지게 하는걸 원래 기존에 만들어둔 애니메이션 컴포넌트가 아닌 다른 코드를 작성해 수정했어요 !!! 훨씬 자연스러워 졌답니다 !! 기존엔 스크롤에 반응하는 애니메이션이 아니고, viewPort 에 반응하는 애니메이션이었어서 가만히만 있어도 화살표가 없어졌거든요. 적용된 화면은 영상을 참고해주시고, 코드는 변경파일을 확인해주세요 !!
- 원래 토너먼트 애니메이션이 안 보여서 직접 구현 하려고 했는데, 지금은 잘 보이더군요.. 배포 페이지에서 또 안 보이면, 로티 그냥 다 삭제해버리고 직접 구현해야할거 같아요 !!
- 나머지는 다 margin 이나 padding 입니다 !! 코드는 변경사항 확인 적용 화면은 영상 확인 해주세요 !
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->



## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

https://github.com/SWEET-DEVELOPERS/sweet-client/assets/38005874/c626b7f3-ae0e-41ae-8bd5-75ea644702d9




## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
