### PR TITLE
[토너먼트] 2차 QA 스타일 변경사항

### DIFF
--- a/src/components/Tournament/Intro/TournamentIntroContainer.tsx
+++ b/src/components/Tournament/Intro/TournamentIntroContainer.tsx
@@ -8,7 +8,6 @@ import useGetItem from '../../../hooks/queries/tournament/useGetItem';
 import trophy from '../../../assets/img/3dic_trophy3.png';
 import { TrophyNone } from '../../../assets/svg';
 import { useParams } from 'react-router';
-import Header from '../../common/Header';
 import TournamentNoneText from './TournamentNoneText/TournamentNoneText';
 import { GiftData } from '../../../types/tournament';
 import TournamentDeleteButton from './TournamentDeleteButton/TournamentDeleteButton';
@@ -81,7 +80,6 @@ const TournamentIntroContainer = () => {
         </>
       ) : (
         <>
-          <Header />
           <TournamentFlowContainer memberData={tournamentData} roomId={roomId} />
         </>
       )}

--- a/src/components/Tournament/TournamentFlow/TournamentCard/TournamentCard.style.ts
+++ b/src/components/Tournament/TournamentFlow/TournamentCard/TournamentCard.style.ts
@@ -42,7 +42,7 @@ export const TournamentCardWrapper = styled.div<TournamentCardWrapperProps>`
 
   width: 16rem;
   border: ${({ isClicked }) =>
-    isClicked ? '3px solid var(--Pink-P-06, #FF2176)' : '3px solid var(--Gray-G-02, #ebe9ea)'};
+    isClicked ? '2px solid var(--Pink-P-06, #FF2176)' : '2px solid var(--Gray-G-02, #ebe9ea)'};
   border-radius: 12px;
   margin-bottom: 2rem;
   background: ${({ theme }) => theme.colors.white};

--- a/src/components/Tournament/TournamentRanking/TournamentRanking.tsx
+++ b/src/components/Tournament/TournamentRanking/TournamentRanking.tsx
@@ -44,7 +44,7 @@ const TournamentRanking = ({ roomId, giftee }: TournamentRankingProps) => {
               );
             })
           ) : (
-            <p>No data available</p>
+            <p>등록된 선물이 없어요!</p>
           )}
         </S.Wrapper>
       </RankingWrapper>

--- a/src/components/Tournament/TournamentRanking/TournamentRankingCard/TournamentRankingCard.style.ts
+++ b/src/components/Tournament/TournamentRanking/TournamentRankingCard/TournamentRankingCard.style.ts
@@ -8,6 +8,9 @@ export const TournamentRankingCardWrapper = styled.div`
 
   img {
     width: 7.2rem;
+    height: auto;
+    aspect-ratio: 1 / 1;
+
     border-radius: 1.2rem;
   }
 `;

--- a/src/components/Tournament/TournamentRanking/TournamentRankingCard/TournamentRankingCard.style.ts
+++ b/src/components/Tournament/TournamentRanking/TournamentRankingCard/TournamentRankingCard.style.ts
@@ -1,5 +1,4 @@
-import styled from "styled-components";
-
+import styled from 'styled-components';
 
 export const TournamentRankingCardWrapper = styled.div`
   display: flex;
@@ -19,5 +18,12 @@ export const InfoWrapper = styled.div`
 `;
 
 export const Title = styled.p`
+  overflow: hidden;
+  white-space: normal;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: keep-all; // 문단으로 끊어져서 줄바꿈 됨
   ${({ theme }) => theme.fonts.body_05};
 `;

--- a/src/components/Tournament/TournamentRanking/TournamentRankingCard/TournamentRankingCard.style.ts
+++ b/src/components/Tournament/TournamentRanking/TournamentRankingCard/TournamentRankingCard.style.ts
@@ -24,6 +24,6 @@ export const Title = styled.p`
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  word-break: keep-all; // 문단으로 끊어져서 줄바꿈 됨
+  word-break: keep-all;
   ${({ theme }) => theme.fonts.body_05};
 `;

--- a/src/components/Tournament/TournamentRanking/TournamentRankingTitle/TournamentRankingTitle.style.ts
+++ b/src/components/Tournament/TournamentRanking/TournamentRankingTitle/TournamentRankingTitle.style.ts
@@ -80,7 +80,7 @@ export const ButtonWrapper = styled.div`
 `;
 
 export const Title = styled.p`
-  margin-bottom: 0.8;
+  margin-bottom: 0.8rem;
   color: ${({ theme }) => theme.colors.Black};
   text-align: center;
   font-family: SUIT;

--- a/src/components/Tournament/TournamentRanking/TournamentRankingTitle/TournamentRankingTitle.style.ts
+++ b/src/components/Tournament/TournamentRanking/TournamentRankingTitle/TournamentRankingTitle.style.ts
@@ -26,8 +26,10 @@ export const LinkButton = styled.button`
 
   p {
     display: inline-flex;
-    align-items: flex-end;
+    align-items: center;
+    padding: 1.1rem;
     gap: 8px;
+
     ${({ theme }) => theme.fonts.body_09};
   }
 `;


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #419 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] 토너먼트 랭킹 말 줄임표
- [x] 토너먼트 랭킹 이미지 비율 1:1
- [x] 토너먼트 랭킹 타이틀 간격 조정


## Need Review
- 간단한 스타일 사항들 수정했습니다~ 말 줄임표 이제 마스터 한 것 같네요 ㅎㅎ!


## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
<img width="520" alt="스크린샷 2024-02-29 오후 5 44 42" src="https://github.com/SWEET-DEVELOPERS/sweet-client/assets/104339899/13e85153-a48e-4aee-b348-63b0a462f38a">

<img width="394" alt="스크린샷 2024-02-29 오후 5 30 11" src="https://github.com/SWEET-DEVELOPERS/sweet-client/assets/104339899/44c4ccf8-b938-497b-934d-95fe347f61fa">


## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
[말줄임표 마스터하기 참고 레퍼런스](https://velog.io/@april_5/CSS-ellipsis-%EB%A7%90%EC%A4%84%EC%9E%84-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0)
