### PR TITLE
[선물 등록] 선물 등록 완료 버튼 활성화 기능 수정

### DIFF
--- a/src/components/GiftAdd/AddGiftFooter/AddGiftFooter.tsx
+++ b/src/components/GiftAdd/AddGiftFooter/AddGiftFooter.tsx
@@ -29,7 +29,7 @@ const AddGiftFooter = ({
   roomId,
   setStep,
   isActivated,
-  name,
+  // name,
   cost,
   link,
   file,

--- a/src/components/GiftAdd/AddGiftFooter/AddGiftFooter.tsx
+++ b/src/components/GiftAdd/AddGiftFooter/AddGiftFooter.tsx
@@ -3,6 +3,7 @@ import GiftAddNextBtn from '../AddGiftLink/common/GiftAddNextBtn/GiftAddNextBtn'
 import * as S from './AddGiftFooter.styled';
 import { AddGiftInfo } from '../../../types/gift';
 import usePutImageUrlToS3 from '../../../hooks/usePutImageUrlToS3';
+import { useAddGiftContext } from '../../../context/AddGift/AddGiftContext';
 
 interface AddGiftFooterProps {
   targetDate: string;
@@ -54,6 +55,7 @@ const AddGiftFooter = ({
     setLinkText,
   });
   const { putImageUrlToS3 } = usePutImageUrlToS3(roomId);
+  const { addGiftInfo } = useAddGiftContext();
 
   const onClick = async () => {
     setIsLoading(true);
@@ -62,7 +64,7 @@ const AddGiftFooter = ({
       try {
         await mutation.mutateAsync({
           roomId: roomId,
-          name: name,
+          name: addGiftInfo.name,
           cost: cost,
           imageUrl: imageUrlS3,
           url: link,

--- a/src/components/GiftAdd/AddGiftFooter/AddGiftFooter.tsx
+++ b/src/components/GiftAdd/AddGiftFooter/AddGiftFooter.tsx
@@ -18,6 +18,9 @@ interface AddGiftFooterProps {
   fileName: string;
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setNameText: React.Dispatch<React.SetStateAction<string>>;
+  setPriceText: React.Dispatch<React.SetStateAction<number | null>>;
+  setLinkText: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const AddGiftFooter = ({
@@ -34,16 +37,24 @@ const AddGiftFooter = ({
   updateAddGiftInfo,
   setIsLoading,
   setIsModalOpen,
+  setNameText,
+  setPriceText,
+  setLinkText,
 }: AddGiftFooterProps) => {
-  const { mutation } = usePostGift(
+  const { mutation } = usePostGift({
     roomId,
     targetDate,
     setStep,
     updateAddGiftInfo,
     setIsLoading,
     setIsModalOpen,
-  );
+    setNameText,
+    setPriceText,
+    setImageUrl,
+    setLinkText,
+  });
   const { putImageUrlToS3 } = usePutImageUrlToS3(roomId);
+
   const onClick = async () => {
     setIsLoading(true);
     const { imageUrlS3 } = await putImageUrlToS3({ fileName, file, roomId, setImageUrl });

--- a/src/components/GiftAdd/AddGiftLayout/AddGiftWithLinkLayout.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/AddGiftWithLinkLayout.tsx
@@ -25,6 +25,12 @@ interface AddGiftWithLinkLayoutProps {
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   isModalOpen: boolean;
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  nameText: string;
+  setNameText: React.Dispatch<React.SetStateAction<string>>;
+  priceText: number | null;
+  setPriceText: React.Dispatch<React.SetStateAction<number | null>>;
+  imageUrl: string;
+  setImageUrl: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const AddGiftWithLinkLayout = ({
@@ -40,13 +46,17 @@ const AddGiftWithLinkLayout = ({
   setIsLoading,
   isModalOpen,
   setIsModalOpen,
+  nameText,
+  setNameText,
+  priceText,
+  setPriceText,
+  imageUrl,
+  setImageUrl,
 }: AddGiftWithLinkLayoutProps) => {
   const [isActivated, setIsActivated] = useState(
     !!addGiftInfo.name && !!addGiftInfo.cost && !!addGiftInfo.imageUrl,
   );
-  const [nameText, setNameText] = useState<string>(addGiftInfo.name);
-  const [priceText, setPriceText] = useState<number | null>(addGiftInfo.cost);
-  const [imageUrl, setImageUrl] = useState<string>(addGiftInfo.imageUrl);
+
   const [fileName, setFileName] = useState<string>('');
   const [file, setFile] = useState<File | null>(null);
   const [, setIsImageUploaded] = useState<boolean>(false);
@@ -112,6 +122,7 @@ const AddGiftWithLinkLayout = ({
       />
       <ShowLink link={link} />
       <WriteItemInfo
+        imageUrl={imageUrl}
         setIsActivated={setIsActivated}
         setName={setNameText}
         setCost={setPriceText}

--- a/src/components/GiftAdd/AddGiftLayout/AddGiftWithLinkLayout.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/AddGiftWithLinkLayout.tsx
@@ -14,6 +14,7 @@ import { useUpdateGifteeNameContext } from '../../../context/GifteeName/GifteeNa
 
 interface AddGiftWithLinkLayoutProps {
   link: string;
+  setLinkText: React.Dispatch<React.SetStateAction<string>>;
   roomId: number;
   step: number;
   setStep: React.Dispatch<React.SetStateAction<number>>;
@@ -35,6 +36,7 @@ interface AddGiftWithLinkLayoutProps {
 
 const AddGiftWithLinkLayout = ({
   link,
+  setLinkText,
   roomId,
   step,
   setStep,
@@ -79,6 +81,7 @@ const AddGiftWithLinkLayout = ({
       const convertResult = await useConvertURLtoFile({
         url: openGraph.image,
         setStep,
+        setImageUrl,
         setModalStatus,
         updateAddGiftInfo,
       });
@@ -143,6 +146,9 @@ const AddGiftWithLinkLayout = ({
         setImageUrl={setImageUrl}
         setIsLoading={setIsLoading}
         setIsModalOpen={setIsModalOpen}
+        setNameText={setNameText}
+        setPriceText={setPriceText}
+        setLinkText={setLinkText}
       />
     </S.AddGiftWithLinkLayoutWrapper>
   );

--- a/src/components/GiftAdd/AddGiftLayout/AddGiftWithoutLinkLayout.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/AddGiftWithoutLinkLayout.tsx
@@ -31,6 +31,10 @@ interface AddGiftWithLinkLayoutProps {
   setPriceText: React.Dispatch<React.SetStateAction<number | null>>;
   imageUrl: string;
   setImageUrl: React.Dispatch<React.SetStateAction<string>>;
+  file: File | null;
+  setFile: React.Dispatch<React.SetStateAction<File | null>>;
+  fileName: string;
+  setFileName: React.Dispatch<React.SetStateAction<string>>;
 }
 
 // 직접 입력 화면
@@ -53,14 +57,18 @@ export const AddGiftWithoutLinkLayout = ({
   setPriceText,
   imageUrl,
   setImageUrl,
+  file,
+  setFile,
+  fileName,
+  setFileName,
 }: AddGiftWithLinkLayoutProps) => {
   console.log('오잉');
   const [isActivated, setIsActivated] = useState(
     !!addGiftInfo.name && !!addGiftInfo.cost && !!addGiftInfo.imageUrl,
   );
 
-  const [fileName, setFileName] = useState<string>('');
-  const [file, setFile] = useState<File | null>(null);
+  // const [fileName, setFileName] = useState<string>('');
+  // const [file, setFile] = useState<File | null>(null);
   const [, setIsImageUploaded] = useState<boolean>(false);
   const [, setPreviewImage] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(modalStatus);
@@ -140,6 +148,9 @@ export const AddGiftWithoutLinkLayout = ({
         setImageUrl={setImageUrl}
         setIsLoading={setIsLoading}
         setIsModalOpen={setIsDuplicateModalOpen}
+        setNameText={setNameText}
+        setPriceText={setPriceText}
+        setLinkText={setLinkText}
       />
     </S.AddGiftWithLinkLayoutWrapper>
   );

--- a/src/components/GiftAdd/AddGiftLayout/AddGiftWithoutLinkLayout.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/AddGiftWithoutLinkLayout.tsx
@@ -25,6 +25,12 @@ interface AddGiftWithLinkLayoutProps {
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   isDuplicateModalOpen: boolean;
   setIsDuplicateModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  nameText: string;
+  setNameText: React.Dispatch<React.SetStateAction<string>>;
+  priceText: number | null;
+  setPriceText: React.Dispatch<React.SetStateAction<number | null>>;
+  imageUrl: string;
+  setImageUrl: React.Dispatch<React.SetStateAction<string>>;
 }
 
 // 직접 입력 화면
@@ -41,13 +47,18 @@ export const AddGiftWithoutLinkLayout = ({
   setIsLoading,
   isDuplicateModalOpen,
   setIsDuplicateModalOpen,
+  nameText,
+  setNameText,
+  priceText,
+  setPriceText,
+  imageUrl,
+  setImageUrl,
 }: AddGiftWithLinkLayoutProps) => {
+  console.log('오잉');
   const [isActivated, setIsActivated] = useState(
-    !!addGiftInfo.name && !!addGiftInfo.cost && !!addGiftInfo.url && !!addGiftInfo.imageUrl,
+    !!addGiftInfo.name && !!addGiftInfo.cost && !!addGiftInfo.imageUrl,
   );
-  const [nameText, setNameText] = useState<string>(addGiftInfo.name);
-  const [priceText, setPriceText] = useState<number | null>(addGiftInfo.cost);
-  const [imageUrl, setImageUrl] = useState<string>(addGiftInfo.imageUrl);
+
   const [fileName, setFileName] = useState<string>('');
   const [file, setFile] = useState<File | null>(null);
   const [, setIsImageUploaded] = useState<boolean>(false);

--- a/src/components/GiftAdd/AddGiftLayout/common/AddGiftImg/AddGiftImg.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/common/AddGiftImg/AddGiftImg.tsx
@@ -2,6 +2,7 @@ import * as S from './AddGiftImg.styled';
 import { IcEmptyThumbnail, IcImgEditBtn } from '../../../../../assets/svg';
 import { OpenGraphResponseType } from '../../../../../types/etc';
 import useHandleImageUpload from '../../../../../hooks/useHandleImageUpload';
+import { useAddGiftContext } from '../../../../../context/AddGift/AddGiftContext';
 
 interface AddGiftImgProps {
   imageUrl: string;
@@ -30,9 +31,12 @@ const AddGiftImg = ({
     setPreviewImage,
     setIsImageUploaded,
   });
+
+  const { addGiftInfo } = useAddGiftContext();
+  console.log('ADDGIFTINFO 이미지', addGiftInfo.imageUrl);
   return (
     <>
-      {openGraph?.image !== '' || imageUrl !== '' ? (
+      {openGraph?.image !== '' || imageUrl !== '' || addGiftInfo.imageUrl !== '' ? (
         <>
           <S.IcEmptyThumbnailWrapper>
             <input
@@ -46,7 +50,13 @@ const AddGiftImg = ({
               {imageUrl ? (
                 <S.ThumbnailWrapper>
                   <S.ImgPreview
-                    src={openGraph?.image ? openGraph.image : imageUrl}
+                    src={
+                      openGraph?.image
+                        ? openGraph.image
+                        : imageUrl
+                          ? imageUrl
+                          : addGiftInfo.imageUrl
+                    }
                     alt='preview'
                     style={{
                       position: 'relative',

--- a/src/components/GiftAdd/AddGiftLayout/common/WriteItemInfo/WithoutLinkWriteItemInfo.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/common/WriteItemInfo/WithoutLinkWriteItemInfo.tsx
@@ -1,5 +1,7 @@
 import * as S from './WriteItemInfo.styled';
 import ItemTextField from '../../../ItemTextField/ItemTextField';
+import { toast } from 'react-toastify';
+import { useAddGiftContext } from '../../../../../context/AddGift/AddGiftContext';
 
 interface WriteItemInfoProps {
   imageUrl: string;
@@ -23,12 +25,23 @@ const WriteItemInfo = ({
   url,
 }: WriteItemInfoProps) => {
   const handleSetIsActivated = (newNameText: string, newPriceText: string) => {
-    if (newNameText.length > 0 && newPriceText.length > 0 && imageUrl !== '') {
+    console.log(' newNameText', newNameText);
+    console.log(' newPriceText', newPriceText);
+    console.log('imageUrl', imageUrl);
+    if (
+      newNameText.length > 0 &&
+      newPriceText !== undefined &&
+      newPriceText !== null &&
+      newPriceText.length > 0 &&
+      imageUrl
+    ) {
       setIsActivated(true);
     } else {
       setIsActivated(false);
     }
   };
+
+  const { addGiftInfo } = useAddGiftContext();
 
   const handleNameTextChange = (newText: string) => {
     setName(newText);
@@ -37,11 +50,32 @@ const WriteItemInfo = ({
     }
   };
 
-  const handlePriceTextChange = (newCost: number | null) => {
-    if (newCost !== null) {
-      setCost(newCost);
-      handleSetIsActivated(name, newCost.toString());
+  const handlePriceTextChange = (newText: string) => {
+    if (newText === '') {
+      setCost(null);
+      handleSetIsActivated(name, '');
+      return;
     }
+
+    const parsedCost = Number(newText);
+
+    if (!isNaN(parsedCost)) {
+      setCost(parsedCost);
+      handleSetIsActivated(name, parsedCost.toString());
+      return;
+    }
+
+    toast.info('가격은 숫자만 입력 가능합니다.', {
+      position: 'bottom-center',
+      autoClose: 700,
+      hideProgressBar: true,
+      closeOnClick: false,
+      pauseOnHover: false,
+      draggable: false,
+      progress: undefined,
+      theme: 'colored',
+      icon: false,
+    });
   };
 
   const handleLinkTextChange = (newText: string) => {
@@ -54,18 +88,18 @@ const WriteItemInfo = ({
         type='text'
         text={name}
         handleTextChange={handleNameTextChange}
-        placeholderText='상품명을 입력해주세요'
+        placeholderText='상품명을 입력해 주세요'
         categoryTitle='상품이름'
       />
       <ItemTextField
-        text={cost ? cost.toString() : ''}
-        handleTextChange={(newText) => handlePriceTextChange(Number(newText))}
+        text={cost ? cost : cost === null ? '' : addGiftInfo.cost === null ? '' : addGiftInfo.cost}
+        handleTextChange={handlePriceTextChange}
         type='number'
         categoryTitle='가격'
         placeholderText='가격을 입력해주세요'
       />
       <ItemTextField
-        text={url}
+        text={url ? url : addGiftInfo.url}
         handleTextChange={handleLinkTextChange}
         categoryTitle='링크'
         placeholderText='링크를 입력해주세요 (선택)'

--- a/src/components/GiftAdd/AddGiftLayout/common/WriteItemInfo/WithoutLinkWriteItemInfo.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/common/WriteItemInfo/WithoutLinkWriteItemInfo.tsx
@@ -88,7 +88,7 @@ const WriteItemInfo = ({
         type='text'
         text={name}
         handleTextChange={handleNameTextChange}
-        placeholderText='상품명을 입력해 주세요'
+        placeholderText='상품명을 입력해주세요'
         categoryTitle='상품이름'
       />
       <ItemTextField
@@ -99,7 +99,7 @@ const WriteItemInfo = ({
         placeholderText='가격을 입력해주세요'
       />
       <ItemTextField
-        text={url ? url : addGiftInfo.url}
+        text={url ? url : url === '' ? '' : addGiftInfo.url}
         handleTextChange={handleLinkTextChange}
         categoryTitle='링크'
         placeholderText='링크를 입력해주세요 (선택)'

--- a/src/components/GiftAdd/AddGiftLayout/common/WriteItemInfo/WithoutLinkWriteItemInfo.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/common/WriteItemInfo/WithoutLinkWriteItemInfo.tsx
@@ -24,10 +24,9 @@ const WriteItemInfo = ({
   cost,
   url,
 }: WriteItemInfoProps) => {
+  const { addGiftInfo, updateAddGiftInfo } = useAddGiftContext();
+
   const handleSetIsActivated = (newNameText: string, newPriceText: string) => {
-    console.log(' newNameText', newNameText);
-    console.log(' newPriceText', newPriceText);
-    console.log('imageUrl', imageUrl);
     if (
       newNameText.length > 0 &&
       newPriceText !== undefined &&
@@ -41,10 +40,10 @@ const WriteItemInfo = ({
     }
   };
 
-  const { addGiftInfo } = useAddGiftContext();
-
   const handleNameTextChange = (newText: string) => {
     setName(newText);
+    updateAddGiftInfo({ name: newText });
+
     if (cost !== null) {
       handleSetIsActivated(newText, cost.toString());
     }

--- a/src/components/GiftAdd/AddGiftLayout/common/WriteItemInfo/WriteItemInfo.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/common/WriteItemInfo/WriteItemInfo.tsx
@@ -20,6 +20,8 @@ const WriteItemInfo = ({
   name,
   cost,
 }: WriteItemInfoProps) => {
+  const { addGiftInfo, updateAddGiftInfo } = useAddGiftContext();
+
   const handleSetIsActivated = (newNameText: string, newPriceText: string) => {
     if (
       newNameText.length > 0 &&
@@ -34,10 +36,9 @@ const WriteItemInfo = ({
     }
   };
 
-  const { addGiftInfo } = useAddGiftContext();
-
   const handleNameTextChange = (newText: string) => {
     setName(newText);
+    updateAddGiftInfo({ name: newText });
     if (cost !== null) {
       handleSetIsActivated(newText, cost.toString());
     }
@@ -46,6 +47,7 @@ const WriteItemInfo = ({
   const handlePriceTextChange = (newText: string) => {
     if (newText === '') {
       setCost(null);
+      updateAddGiftInfo({ cost: null });
       handleSetIsActivated(name, '');
       return;
     }
@@ -75,7 +77,7 @@ const WriteItemInfo = ({
     <S.WriteItemInfoWrapper>
       <ItemTextField
         type='text'
-        text={name}
+        text={addGiftInfo.name ? addGiftInfo.name : name}
         handleTextChange={handleNameTextChange}
         placeholderText='상품명을 입력해주세요'
         categoryTitle='상품이름'

--- a/src/components/GiftAdd/AddGiftLayout/common/WriteItemInfo/WriteItemInfo.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/common/WriteItemInfo/WriteItemInfo.tsx
@@ -1,23 +1,40 @@
 import * as S from './WriteItemInfo.styled';
 import ItemTextField from '../../../ItemTextField/ItemTextField';
+import { toast } from 'react-toastify';
+import { useAddGiftContext } from '../../../../../context/AddGift/AddGiftContext';
 
 interface WriteItemInfoProps {
   setIsActivated: React.Dispatch<React.SetStateAction<boolean>>;
-
+  imageUrl: string;
   setName: React.Dispatch<React.SetStateAction<string>>;
   setCost: React.Dispatch<React.SetStateAction<number | null>>;
   name: string;
   cost: number | null;
 }
 
-const WriteItemInfo = ({ setIsActivated, setName, setCost, name, cost }: WriteItemInfoProps) => {
+const WriteItemInfo = ({
+  imageUrl,
+  setIsActivated,
+  setName,
+  setCost,
+  name,
+  cost,
+}: WriteItemInfoProps) => {
   const handleSetIsActivated = (newNameText: string, newPriceText: string) => {
-    if (newNameText.length > 0 && newPriceText.length > 0) {
+    if (
+      newNameText.length > 0 &&
+      newPriceText !== undefined &&
+      newPriceText !== null &&
+      newPriceText.length > 0 &&
+      imageUrl
+    ) {
       setIsActivated(true);
     } else {
       setIsActivated(false);
     }
   };
+
+  const { addGiftInfo } = useAddGiftContext();
 
   const handleNameTextChange = (newText: string) => {
     setName(newText);
@@ -26,9 +43,32 @@ const WriteItemInfo = ({ setIsActivated, setName, setCost, name, cost }: WriteIt
     }
   };
 
-  const handlePriceTextChange = (newCost: number) => {
-    setCost(newCost);
-    handleSetIsActivated(name, newCost.toString());
+  const handlePriceTextChange = (newText: string) => {
+    if (newText === '') {
+      setCost(null);
+      handleSetIsActivated(name, '');
+      return;
+    }
+
+    const parsedCost = Number(newText);
+
+    if (!isNaN(parsedCost)) {
+      setCost(parsedCost);
+      handleSetIsActivated(name, parsedCost.toString());
+      return;
+    }
+
+    toast.info('가격은 숫자만 입력 가능합니다.', {
+      position: 'bottom-center',
+      autoClose: 700,
+      hideProgressBar: true,
+      closeOnClick: false,
+      pauseOnHover: false,
+      draggable: false,
+      progress: undefined,
+      theme: 'colored',
+      icon: false,
+    });
   };
 
   return (
@@ -41,8 +81,8 @@ const WriteItemInfo = ({ setIsActivated, setName, setCost, name, cost }: WriteIt
         categoryTitle='상품이름'
       />
       <ItemTextField
-        text={cost ? cost.toString() : ''}
-        handleTextChange={(newText) => handlePriceTextChange(Number(newText))}
+        text={cost ? cost : cost === null ? '' : addGiftInfo.cost === null ? '' : addGiftInfo.cost}
+        handleTextChange={handlePriceTextChange}
         type='number'
         categoryTitle='가격'
         placeholderText='가격을 입력해주세요'

--- a/src/components/GiftAdd/AddGiftLink/GiftAddFirstLinkLayout/GiftAddFirstLinkLayout.tsx
+++ b/src/components/GiftAdd/AddGiftLink/GiftAddFirstLinkLayout/GiftAddFirstLinkLayout.tsx
@@ -42,7 +42,6 @@ const GiftAddFirstLinkLayout = ({
 
   const { gifteeName } = useUpdateGifteeNameContext();
 
-
   const fetchOpenGraph = (BaseUrl: string) => {
     try {
       const response = mutation.mutate(
@@ -61,6 +60,8 @@ const GiftAddFirstLinkLayout = ({
             setStep(2);
           },
           onError: () => {
+            updateAddGiftInfo({ imageUrl: '' });
+            setOpenGraph({ title: '', image: '' });
             setModalStatus(true);
             setStep(3);
           },

--- a/src/components/GiftAdd/AddGiftLink/common/LinkAddHeader/LinkAddHeader.tsx
+++ b/src/components/GiftAdd/AddGiftLink/common/LinkAddHeader/LinkAddHeader.tsx
@@ -28,13 +28,12 @@ const LinkAddHeader = ({
 }: LinkAddHeaderProps) => {
   const onClickBackBtn = () => {
     if (step === 1) {
-      updateAddGiftInfo({ url: url });
+      updateAddGiftInfo({ name: '', cost: '', imageUrl: '', url: '' });
       setStep(0);
     } else if (step === 2 || step === 3) {
       updateAddGiftInfo({ name: name, cost: cost, imageUrl: imageUrl });
       setStep(1);
     }
-    updateAddGiftInfo({ name: '', cost: '', imageUrl: '', url: '' });
   };
   return (
     <S.LinkAddHeaderWrapper>

--- a/src/components/GiftAdd/AddGiftLink/common/LinkAddHeader/LinkAddHeader.tsx
+++ b/src/components/GiftAdd/AddGiftLink/common/LinkAddHeader/LinkAddHeader.tsx
@@ -24,7 +24,7 @@ const LinkAddHeader = ({
   imageUrl,
   url,
   updateAddGiftInfo,
-  gifteeName
+  gifteeName,
 }: LinkAddHeaderProps) => {
   const onClickBackBtn = () => {
     if (step === 1) {
@@ -34,6 +34,7 @@ const LinkAddHeader = ({
       updateAddGiftInfo({ name: name, cost: cost, imageUrl: imageUrl });
       setStep(1);
     }
+    updateAddGiftInfo({ name: '', cost: '', imageUrl: '', url: '' });
   };
   return (
     <S.LinkAddHeaderWrapper>
@@ -47,7 +48,7 @@ const LinkAddHeader = ({
           cursor: 'pointer',
         }}
       />
-      <MiniTimer targetDate={targetDate} giftee={gifteeName}/>
+      <MiniTimer targetDate={targetDate} giftee={gifteeName} />
     </S.LinkAddHeaderWrapper>
   );
 };

--- a/src/components/GiftAdd/AddGiftLink/common/LinkAddHeader/LinkAddHeader.tsx
+++ b/src/components/GiftAdd/AddGiftLink/common/LinkAddHeader/LinkAddHeader.tsx
@@ -22,7 +22,7 @@ const LinkAddHeader = ({
   name,
   cost,
   imageUrl,
-  url,
+  // url,
   updateAddGiftInfo,
   gifteeName,
 }: LinkAddHeaderProps) => {

--- a/src/context/AddGift/AddGiftContext.tsx
+++ b/src/context/AddGift/AddGiftContext.tsx
@@ -7,7 +7,7 @@ interface AddGiftInfoContext {
 }
 const initialAddGiftInfo: AddGiftInfo = {
   name: '',
-  cost: 0,
+  cost: null,
   imageUrl: '',
   url: '',
 };

--- a/src/hooks/queries/gift/usePostGift.tsx
+++ b/src/hooks/queries/gift/usePostGift.tsx
@@ -4,6 +4,19 @@ import { AddGiftInfo, GiftPostRequestType } from '../../../types/gift';
 import { useNavigate } from 'react-router-dom';
 import { MY_GIFT_QUERY_KEY } from './useGetMyGift';
 
+interface PostGiftProps {
+  roomId: number;
+  targetDate: string;
+  setStep: React.Dispatch<React.SetStateAction<number>>;
+  updateAddGiftInfo: (newInfo: Partial<AddGiftInfo>) => void;
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setImageUrl: React.Dispatch<React.SetStateAction<string>>;
+  setNameText: React.Dispatch<React.SetStateAction<string>>;
+  setLinkText: React.Dispatch<React.SetStateAction<string>>;
+  setPriceText: React.Dispatch<React.SetStateAction<number | null>>;
+}
+
 export const postNewGift = async (body: GiftPostRequestType) => {
   try {
     const response = await post(`/gift`, body);
@@ -18,14 +31,18 @@ export const postNewGift = async (body: GiftPostRequestType) => {
   }
 };
 
-export const usePostGift = (
-  roomId: number,
-  targetDate: string,
-  setStep: React.Dispatch<React.SetStateAction<number>>,
-  updateAddGiftInfo: (newInfo: Partial<AddGiftInfo>) => void,
-  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>,
-  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>,
-) => {
+export const usePostGift = ({
+  roomId,
+  targetDate,
+  setStep,
+  updateAddGiftInfo,
+  setIsLoading,
+  setIsModalOpen,
+  setNameText,
+  setPriceText,
+  setImageUrl,
+  setLinkText,
+}: PostGiftProps) => {
   const navigate = useNavigate();
 
   const queryClient = useQueryClient();
@@ -39,6 +56,10 @@ export const usePostGift = (
       setStep(0);
       setIsLoading(false);
       updateAddGiftInfo({ name: '', cost: 0, imageUrl: '', url: '' });
+      setNameText('');
+      setPriceText(null);
+      setImageUrl('');
+      setLinkText('');
     },
     onError: (error) => {
       console.log('선물 등록 에러!!', error.message);

--- a/src/hooks/useConvertURLtoFile.tsx
+++ b/src/hooks/useConvertURLtoFile.tsx
@@ -5,12 +5,14 @@ interface convertURLtoFileProps {
   setStep: React.Dispatch<React.SetStateAction<number>>;
   setModalStatus: React.Dispatch<React.SetStateAction<boolean>>;
   updateAddGiftInfo: (newInfo: Partial<AddGiftInfo>) => void;
+  setImageUrl: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const useConvertURLtoFile = async ({
   url,
   setStep,
   setModalStatus,
+  setImageUrl,
   updateAddGiftInfo,
 }: convertURLtoFileProps) => {
   console.log('들어오고 있는 url', url);
@@ -29,6 +31,7 @@ const useConvertURLtoFile = async ({
     return { convertedOgFile };
   } catch (error) {
     console.error('error?', error);
+    setImageUrl('');
     updateAddGiftInfo({ imageUrl: '' });
     setModalStatus(true);
     setStep(3);

--- a/src/hooks/useHandleImageUpload.tsx
+++ b/src/hooks/useHandleImageUpload.tsx
@@ -1,4 +1,3 @@
-import { useAddGiftContext } from '../context/AddGift/AddGiftContext';
 import { OpenGraphResponseType } from '../types/etc';
 import useParseFileName from './useParseFileName';
 

--- a/src/hooks/useHandleImageUpload.tsx
+++ b/src/hooks/useHandleImageUpload.tsx
@@ -1,3 +1,4 @@
+import { useAddGiftContext } from '../context/AddGift/AddGiftContext';
 import { OpenGraphResponseType } from '../types/etc';
 import useParseFileName from './useParseFileName';
 

--- a/src/pages/GiftAdd/GiftAddPage.tsx
+++ b/src/pages/GiftAdd/GiftAddPage.tsx
@@ -11,7 +11,8 @@ import Loading from '../Loading/Loading';
 const GiftAddPage = () => {
   const [step, setStep] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
-
+  const { addGiftInfo, updateAddGiftInfo } = useAddGiftContext();
+  console.log('AddGiftINFO', addGiftInfo);
   // case 1 링크 입력 페이지 state들
   const [itemNum, setItemNum] = useState(0);
   const [linkText, setLinkText] = useState<string>('');
@@ -20,13 +21,15 @@ const GiftAddPage = () => {
   const [openGraph, setOpenGraph] = useState<OpenGraphResponseType>({ title: '', image: '' });
   const [modalStatus, setModalStatus] = useState(false);
   const [duplicateModalStatus, setDuplicateModalStatus] = useState(false);
+  const [nameText, setNameText] = useState<string>(addGiftInfo.name);
+  const [priceText, setPriceText] = useState<number | null>(addGiftInfo.cost);
+  const [imageUrl, setImageUrl] = useState<string>(addGiftInfo.imageUrl);
 
   const params = useParams();
   const roomId = params.roomId;
   const targetDate = params.targetTime;
   const roomIdNumber = parseInt(roomId || '');
 
-  const { addGiftInfo, updateAddGiftInfo } = useAddGiftContext();
   switch (step) {
     case 0:
       return (
@@ -73,6 +76,12 @@ const GiftAddPage = () => {
           setIsLoading={setIsLoading}
           isModalOpen={duplicateModalStatus}
           setIsModalOpen={setDuplicateModalStatus}
+          nameText={nameText}
+          setNameText={setNameText}
+          priceText={priceText}
+          setPriceText={setPriceText}
+          imageUrl={imageUrl}
+          setImageUrl={setImageUrl}
         />
       );
 
@@ -94,6 +103,12 @@ const GiftAddPage = () => {
           setIsLoading={setIsLoading}
           isDuplicateModalOpen={duplicateModalStatus}
           setIsDuplicateModalOpen={setDuplicateModalStatus}
+          nameText={nameText}
+          setNameText={setNameText}
+          priceText={priceText}
+          setPriceText={setPriceText}
+          imageUrl={imageUrl}
+          setImageUrl={setImageUrl}
         />
       );
   }

--- a/src/pages/GiftAdd/GiftAddPage.tsx
+++ b/src/pages/GiftAdd/GiftAddPage.tsx
@@ -23,7 +23,11 @@ const GiftAddPage = () => {
   const [duplicateModalStatus, setDuplicateModalStatus] = useState(false);
   const [nameText, setNameText] = useState<string>(addGiftInfo.name);
   const [priceText, setPriceText] = useState<number | null>(addGiftInfo.cost);
+
+  // 이미지 관련 state들
   const [imageUrl, setImageUrl] = useState<string>(addGiftInfo.imageUrl);
+  const [fileName, setFileName] = useState<string>('');
+  const [file, setFile] = useState<File | null>(null);
 
   const params = useParams();
   const roomId = params.roomId;
@@ -81,6 +85,7 @@ const GiftAddPage = () => {
           priceText={priceText}
           setPriceText={setPriceText}
           imageUrl={imageUrl}
+          setLinkText={setLinkText}
           setImageUrl={setImageUrl}
         />
       );
@@ -109,6 +114,10 @@ const GiftAddPage = () => {
           setPriceText={setPriceText}
           imageUrl={imageUrl}
           setImageUrl={setImageUrl}
+          file={file}
+          setFile={setFile}
+          fileName={fileName}
+          setFileName={setFileName}
         />
       );
   }


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #441 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] 어떤 순서로 입력하더라도 완료 버튼이 제대로 활성화/비활성화 되도록 수정

## Need Review
- case문으로 한 페이지 안에서 여러 컴포넌트들을 갈아 끼우고 있는 형태라서 state 변동에 즉각적인 반응을 주기 위해서는 prop을 모든 페이지들을 관리하는 컴포넌트로 빼주어야 해서 굉장히 많은 props drilling을 겪게 되었습니다. 이번 스프린트 이후에 리팩토링이 많이 이루어져야 할 것 같습니다. context 추가에 대해 고민중입니다.
- 예외처리에 집중했습니다.(링크 유무, 뒤로 갔다가 다시 돌아왔을 때, 이름만 바꿨을 때 등등)
- 오픈그래프로 정보를 가져오는 경우 계속 정보들이 초기화되어 context를 사용했습니다.
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->



## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->


https://github.com/SWEET-DEVELOPERS/sweet-client/assets/92876819/e64de033-9feb-49fa-b6e0-6ac190472736



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
