### PR TITLE
[선물 등록] 이미지 url 파일 변환 실패 시 선물 등록 사항 초기화되도록 수정 

### DIFF
--- a/src/components/GiftAdd/AddGiftLayout/AddGiftWithoutLinkLayout.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/AddGiftWithoutLinkLayout.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import AddGiftFooter from '../AddGiftFooter/AddGiftFooter';
 import GiftStatusBar from '../AddGiftLink/common/GiftStatusBar/GiftStatusBar';
 import * as S from './common/AddGiftLayout.styled';
@@ -72,8 +72,8 @@ export const AddGiftWithoutLinkLayout = ({
   const [, setIsImageUploaded] = useState<boolean>(false);
   const [, setPreviewImage] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(modalStatus);
-
   const { gifteeName } = useUpdateGifteeNameContext();
+  // 직접 입력 처음 들어올 시 무조건 이미지는 초기화되도록
 
   const checkPriceNull = (price: number | null) => {
     if (price === null) {
@@ -88,6 +88,10 @@ export const AddGiftWithoutLinkLayout = ({
     setIsModalOpen(false);
     setStep(3);
   };
+
+  useEffect(() => {
+    setImageUrl('');
+  }, []);
 
   return (
     <S.AddGiftWithLinkLayoutWrapper>

--- a/src/components/GiftAdd/AddGiftLayout/AddGiftWithoutLinkLayout.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/AddGiftWithoutLinkLayout.tsx
@@ -72,7 +72,6 @@ export const AddGiftWithoutLinkLayout = ({
   const [, setPreviewImage] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(modalStatus);
   const { gifteeName } = useUpdateGifteeNameContext();
-  // 직접 입력 처음 들어올 시 무조건 이미지는 초기화되도록
 
   const checkPriceNull = (price: number | null) => {
     if (price === null) {
@@ -88,6 +87,7 @@ export const AddGiftWithoutLinkLayout = ({
     setStep(3);
   };
 
+  // 직접 입력 처음 들어올 시 무조건 이미지는 초기화되도록
   useEffect(() => {
     setImageUrl('');
   }, []);

--- a/src/components/GiftAdd/AddGiftLayout/AddGiftWithoutLinkLayout.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/AddGiftWithoutLinkLayout.tsx
@@ -62,7 +62,6 @@ export const AddGiftWithoutLinkLayout = ({
   fileName,
   setFileName,
 }: AddGiftWithLinkLayoutProps) => {
-  console.log('오잉');
   const [isActivated, setIsActivated] = useState(
     !!addGiftInfo.name && !!addGiftInfo.cost && !!addGiftInfo.imageUrl,
   );

--- a/src/components/GiftAdd/AddGiftLayout/common/AddGiftImg/AddGiftImg.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/common/AddGiftImg/AddGiftImg.tsx
@@ -34,6 +34,8 @@ const AddGiftImg = ({
 
   const { addGiftInfo } = useAddGiftContext();
   console.log('ADDGIFTINFO 이미지', addGiftInfo.imageUrl);
+  console.log('ADDGIFTINFO imageurl', imageUrl);
+  console.log('ADDGIFTINFO opengraph image', openGraph?.image);
   return (
     <>
       {openGraph?.image !== '' || imageUrl !== '' || addGiftInfo.imageUrl !== '' ? (

--- a/src/hooks/useConvertURLtoFile.tsx
+++ b/src/hooks/useConvertURLtoFile.tsx
@@ -30,11 +30,11 @@ const useConvertURLtoFile = async ({
     const convertedOgFile = new File([data], filename!, metadata);
     return { convertedOgFile };
   } catch (error) {
-    console.error('error?', error);
-    setImageUrl('');
     updateAddGiftInfo({ imageUrl: '' });
+    setImageUrl('');
     setModalStatus(true);
     setStep(3);
+    console.error('error?', error);
     return { convertedOgFile: null };
   }
 };


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #464 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] 직접 입력 진입 시 이미지 url 초기화 

## Need Review
- 파일 변환 불가능한 오픈 그래프 이미지 url이 들어오는 경우가 있어 직접 입력 화면 진입 시 이미지 url을 무조건 빈 값으로 초기화해주는 코드를 추가했습니다. 더 좋은 방식으로 초기화가 가능할지 고민해봤는데 현재는 이미지 첨부 컴포넌트를 직접 입력과 링크 입력이 공유하고 있어 useEffect를 사용해 초기화하는 방식으로 수정했습니다. 추후 리팩토링하면서 컴포넌트를 하나 더 만들거나 props 정리를 해봐야 할 것 같아요.
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->



## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

https://github.com/SWEET-DEVELOPERS/sweet-client/assets/92876819/5b11d4ef-0124-406e-bb2c-85c2b8f88642




## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
