### PR TITLE
refactor: heic 변환 처리 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "date-fns": "^3.2.0",
     "dayjs": "^1.11.10",
     "file-saver": "^2.0.5",
+    "heic2any": "^0.0.4",
     "html2canvas": "^1.4.1",
     "lottie-web": "^5.12.2",
     "open-graph": "^0.2.6",

--- a/src/components/GiftAdd/AddGiftLayout/common/AddGiftImg/AddGiftImg.tsx
+++ b/src/components/GiftAdd/AddGiftLayout/common/AddGiftImg/AddGiftImg.tsx
@@ -43,7 +43,7 @@ const AddGiftImg = ({
           <S.IcEmptyThumbnailWrapper>
             <input
               type='file'
-              accept='image/jpeg, image/png, image/gif, image/heic, image/webp,'
+              accept='image/jpeg, image/png, image/gif, image/heic, image/webp, image/HEIC'
               style={{ display: 'none' }}
               id='imgInput'
               onChange={handleImageUpload}

--- a/src/hooks/useHandleImageUpload.tsx
+++ b/src/hooks/useHandleImageUpload.tsx
@@ -1,6 +1,7 @@
 import { OpenGraphResponseType } from '../types/etc';
 import useParseFileName from './useParseFileName';
 import Resizer from 'react-image-file-resizer';
+import heic2any from 'heic2any';
 
 interface HandleImageUploadProps {
   openGraph: OpenGraphResponseType | null;
@@ -21,48 +22,52 @@ const useHandleImageUpload = ({
 }: HandleImageUploadProps) => {
   const handleImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = event.target;
+    if (files && files.length > 0) {
+      const selectedFile = files[0];
 
-    const resizeFile = (file: File) =>
-      new Promise((resolve) => {
+      setPreviewImage(URL.createObjectURL(selectedFile));
+
+      try {
+        let convertedFile = selectedFile;
+
+        if (selectedFile.type === 'image/heic' || selectedFile.type === 'image/HEIC') {
+          let blob = selectedFile;
+          const resultBlob = await heic2any({ blob, toType: 'image/webp' });
+          convertedFile = new File(
+            [resultBlob as Blob],
+            selectedFile.name.split('.')[0] + '.webp',
+            { type: 'image/webp', lastModified: new Date().getTime() },
+          );
+        }
+
         Resizer.imageFileResizer(
-          file,
+          convertedFile,
           384,
           384,
           'WEBP',
           75,
           0,
           (uri) => {
-            setFileName((uri as File).name);
-            setFile(uri as File);
-            console.log('FILE', uri);
-            resolve(uri);
+            if (uri instanceof File) {
+              setFileName((uri as File).name);
+              setFile(uri as File);
+              console.log('FILE', uri);
+              setImageUrl(URL.createObjectURL(uri as File));
+              setIsImageUploaded(true);
+
+              if (openGraph) {
+                openGraph.image = '';
+              }
+
+              const imageName = uri.name.trim();
+              useParseFileName({ setFileName, imageString: imageName });
+            }
           },
           'file',
         );
-      });
-
-    if (files && files.length > 0) {
-      const selectedFiles = files as FileList;
-
-      if (files) {
-        try {
-          resizeFile(selectedFiles[0]);
-        } catch (err) {
-          console.log('이미지 용량 압축 중 에러 발생', err);
-        }
+      } catch (err) {
+        console.log('Error processing image:', err);
       }
-
-      setPreviewImage(URL.createObjectURL(selectedFiles[0]));
-
-      setImageUrl(URL.createObjectURL(selectedFiles[0]));
-      setIsImageUploaded(!!selectedFiles?.[0]);
-
-      if (openGraph) {
-        openGraph.image = '';
-      }
-
-      const imageName = selectedFiles[0].name.trim();
-      useParseFileName({ setFileName, imageString: imageName });
     }
   };
   return { handleImageUpload };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3510,6 +3510,11 @@ hasown@^2.0.0:
   dependencies:
     function-bind "^1.1.2"
 
+heic2any@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/heic2any/-/heic2any-0.0.4.tgz#eddb8e6fec53c8583a6e18b65069bb5e8d19028a"
+  integrity sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==
+
 hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -4495,12 +4500,10 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-
 react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
-
 
 react-loading-skeleton@^3.4.0:
   version "3.4.0"


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #488 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] heic 예외처리

## Need Review
- 기존의 이미지 용량 압축 라이브러리는 웹 이미지 형식 기준이라 heic를 input으로 받지 않는 것 같더라고요🥲 하지만 스윗 특성상 핸드폰으로 찍은 사진을 올리는 경우가 많을 것 같아 heic 형식을 변환하는 라이브러리를 적용해서라도 가져가야 할 것 같다고 생각했어요. 다만 이렇게 되면 heic => webp => 압축 이라는 과정으로 늘어나서 heic를 업로드할 때는 시간이 좀 더 걸리는 단점이 생겼어요. 이후에 로딩 뷰를 추가하거나 최적화 가능한 부분은 더 진행해보겠습니다!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->



## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
