### PR TITLE
[마이페이지] 선물방으로 이동 버튼 기능 추가

### DIFF
--- a/src/components/CardRoom/DoneCardRoom.tsx
+++ b/src/components/CardRoom/DoneCardRoom.tsx
@@ -13,7 +13,7 @@ const DoneCardRoom = ({ user, srcImage, userCount, onClick }: DoneCardRoomType) 
   const multiline = user.length > 3 || (/[a-zA-Z]/.test(user) && user.length > 5);
   return (
     <S.CardRoomWrapper onClick={onClick}>
-      <div>
+      <>
         <S.RoomImgWrapper src={srcImage} />
         <S.Text>
           {multiline ? (
@@ -28,7 +28,7 @@ const DoneCardRoom = ({ user, srcImage, userCount, onClick }: DoneCardRoomType) 
           <IcUser style={{ width: '1.6rem', height: '1.6rem', color: '#ACA7A9' }} />
           {userCount}
         </S.CountUser>
-      </div>
+      </>
       <S.TagWrapper>
         <Type3Tag tag='토너먼트 완료' />
       </S.TagWrapper>

--- a/src/components/CardRoom/EditCardRoom.tsx
+++ b/src/components/CardRoom/EditCardRoom.tsx
@@ -25,7 +25,7 @@ const EditCardRoom = ({ user, srcImage, userCount, roomId, date, onClick }: Edit
   return (
     <S.WholeWrapper>
       <S.CardRoomWrapper onClick={onClick}>
-        <div>
+        <>
           <S.RoomImgWrapper src={srcImage} />
           <S.Text>
             {multiline ? (
@@ -48,7 +48,7 @@ const EditCardRoom = ({ user, srcImage, userCount, roomId, date, onClick }: Edit
             />
             {userCount}
           </S.CountUser>
-        </div>
+        </>
         <S.TagWrapper>
           <Type1Tag tag='개설자' />
           {!isFuture ? <Type2Tag tag='토너먼트 진행 중' /> : <Type2Tag tag='선물 등록 중' />}

--- a/src/components/CardRoom/ProgressCardRoom.tsx
+++ b/src/components/CardRoom/ProgressCardRoom.tsx
@@ -18,7 +18,7 @@ const ProgressCardRoom = ({ user, srcImage, userCount, date, onClick }: Progress
 
   return (
     <S.CardRoomWrapper onClick={onClick}>
-      <div>
+      <>
         <S.RoomImgWrapper src={srcImage} />
         <S.Text>
           {multiline ? (
@@ -41,7 +41,7 @@ const ProgressCardRoom = ({ user, srcImage, userCount, date, onClick }: Progress
           />
           {userCount}
         </S.CountUser>
-      </div>
+      </>
       <S.TagWrapper>
         {!isFuture ? <Type2Tag tag='토너먼트 진행 중' /> : <Type2Tag tag='선물 등록 중' />}
       </S.TagWrapper>

--- a/src/pages/MyPage/Detail/DetailDoneRoom/DetailDoneRoom.style.ts
+++ b/src/pages/MyPage/Detail/DetailDoneRoom/DetailDoneRoom.style.ts
@@ -17,15 +17,3 @@ export const RoomWrapper = styled.div`
   gap: 1.5rem;
   padding: 1.6rem 0;
 `;
-
-export const EmptyWrapper = styled.div`
-  ${({ theme: { mixin } }) => mixin.flexCenter({})};
-  height: 100%;
-  gap: 1.2rem;
-  margin: 0 2rem;
-`;
-
-export const EmptyText = styled.div`
-  ${({ theme: { fonts } }) => fonts.body_10};
-  color: ${({ theme: { colors } }) => colors.G_07};
-`;

--- a/src/pages/MyPage/Detail/DetailDoneRoom/DetailDoneRoom.tsx
+++ b/src/pages/MyPage/Detail/DetailDoneRoom/DetailDoneRoom.tsx
@@ -1,7 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { IcLogoEmpty } from '../../../../assets/svg';
 import DoneCardRoom from '../../../../components/CardRoom/DoneCardRoom';
-import BtnSmallStroke from '../../../../components/common/Button/Cta/SmallStroke/BtnSmallStroke';
 import useGetDoneRoom from '../../../../hooks/queries/member/useGetClosedRoom';
 import { ClosedRoomArrayType } from '../../../../types/member';
 import * as S from './DetailDoneRoom.style';

--- a/src/pages/MyPage/Detail/DetailDoneRoom/DetailDoneRoom.tsx
+++ b/src/pages/MyPage/Detail/DetailDoneRoom/DetailDoneRoom.tsx
@@ -6,6 +6,7 @@ import useGetDoneRoom from '../../../../hooks/queries/member/useGetClosedRoom';
 import { ClosedRoomArrayType } from '../../../../types/member';
 import * as S from './DetailDoneRoom.style';
 import LeftIconHeader from '../../../../components/LeftIconHeader/LeftIconHeader';
+import EmptyView from '../EmptyView/EmptyView';
 
 const DetailDoneRoom = () => {
   const navigate = useNavigate();
@@ -30,11 +31,7 @@ const DetailDoneRoom = () => {
             {data.map((item, index) => renderDoneRoomCard(item, index))}
           </S.RoomWrapper>
         ) : (
-          <S.EmptyWrapper title='종료된 선물방'>
-            <IcLogoEmpty style={{ width: '8rem', height: '6.4rem' }} />
-            <S.EmptyText>준비했던 선물이 없어요</S.EmptyText>
-            <BtnSmallStroke customStyle={{ margin: '1.6rem' }}>새로운 선물 준비하기</BtnSmallStroke>
-          </S.EmptyWrapper>
+          <EmptyView title='종료된 선물방' />
         )}
       </>
     </S.DetailDoneRoomWrapper>

--- a/src/pages/MyPage/Detail/DetailProgressRoom/DetailProgress.style.ts
+++ b/src/pages/MyPage/Detail/DetailProgressRoom/DetailProgress.style.ts
@@ -17,16 +17,3 @@ export const RoomWrapper = styled.div`
   gap: 1.5rem;
   padding: 1.6rem 0;
 `;
-
-export const EmptyWrapper = styled.div`
-  ${({ theme: { mixin } }) => mixin.flexCenter({})};
-  height: 100%;
-  gap: 1.2rem;
-  margin: 0 2rem;
-`;
-
-export const EmptyText = styled.div`
-  ${({ theme: { mixin } }) => mixin.flexCenter({})};
-  ${({ theme: { fonts } }) => fonts.body_10};
-  color: ${({ theme: { colors } }) => colors.G_07};
-`;

--- a/src/pages/MyPage/Detail/DetailProgressRoom/DetailProgressRoom.tsx
+++ b/src/pages/MyPage/Detail/DetailProgressRoom/DetailProgressRoom.tsx
@@ -8,6 +8,7 @@ import DateCheck from '../../../../components/DateCheck/DateCheck';
 import { ActiveRoomArrayType } from '../../../../types/member';
 import * as S from './DetailProgress.style';
 import LeftIconHeader from '../../../../components/LeftIconHeader/LeftIconHeader';
+import EmptyView from '../EmptyView/EmptyView';
 
 const DetailProgressRoom = () => {
   const navigate = useNavigate();
@@ -40,11 +41,7 @@ const DetailProgressRoom = () => {
         {Array.isArray(data) && data.length > 0 ? (
           <S.RoomWrapper>{data.map((item, index) => renderRoomCard(item, index))}</S.RoomWrapper>
         ) : (
-          <S.EmptyWrapper title='진행중인 선물방'>
-            <IcLogoEmpty style={{ width: '8rem', height: '6.4rem' }} />
-            <S.EmptyText>준비했던 선물이 없어요</S.EmptyText>
-            <BtnSmallStroke customStyle={{ margin: '1.6rem' }}>새로운 선물 준비하기</BtnSmallStroke>
-          </S.EmptyWrapper>
+          <EmptyView title='진행중인 선물방' />
         )}
       </>
     </S.DetailProgressRoomWrapper>

--- a/src/pages/MyPage/Detail/DetailProgressRoom/DetailProgressRoom.tsx
+++ b/src/pages/MyPage/Detail/DetailProgressRoom/DetailProgressRoom.tsx
@@ -1,8 +1,6 @@
 import { useNavigate } from 'react-router-dom';
-import { IcLogoEmpty } from '../../../../assets/svg';
 import EditCardRoom from '../../../../components/CardRoom/EditCardRoom';
 import ProgressCardRoom from '../../../../components/CardRoom/ProgressCardRoom';
-import BtnSmallStroke from '../../../../components/common/Button/Cta/SmallStroke/BtnSmallStroke';
 import useGetActiveRoom from '../../../../hooks/queries/member/useGetActiveRoom';
 import DateCheck from '../../../../components/DateCheck/DateCheck';
 import { ActiveRoomArrayType } from '../../../../types/member';

--- a/src/pages/MyPage/Detail/EmptyView/EmptyView.style.ts
+++ b/src/pages/MyPage/Detail/EmptyView/EmptyView.style.ts
@@ -2,9 +2,13 @@ import styled from 'styled-components';
 
 export const EmptyViewWrapper = styled.div`
   ${({ theme: { mixin } }) => mixin.flexCenter({})};
+  height: 100%;
+  gap: 1.2rem;
+  margin: 0 2rem;
 `;
 
-export const Text = styled.div`
+export const EmptyText = styled.div`
+  ${({ theme: { mixin } }) => mixin.flexCenter({})};
   ${({ theme: { fonts } }) => fonts.body_10};
   color: ${({ theme: { colors } }) => colors.G_07};
 `;

--- a/src/pages/MyPage/Detail/EmptyView/EmptyView.tsx
+++ b/src/pages/MyPage/Detail/EmptyView/EmptyView.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { IcLogoEmpty } from '../../../../assets/svg';
 import BtnSmallStroke from '../../../../components/common/Button/Cta/SmallStroke/BtnSmallStroke';
 import DetailHeader from '../../../../components/LeftIconHeader/LeftIconHeader';
@@ -8,12 +9,16 @@ interface EmptyViewType {
 }
 
 const EmptyView = ({ title }: EmptyViewType) => {
+  const navigate = useNavigate();
+  const handleClickButton = () => {
+    navigate('/onboarding');
+  };
   return (
     <S.EmptyViewWrapper>
       <DetailHeader title={title} />
       <IcLogoEmpty />
       <S.Text>준비했던 선물이 없어요</S.Text>
-      <BtnSmallStroke>새로운 선물 준바하기</BtnSmallStroke>
+      <BtnSmallStroke onClick={handleClickButton}>새로운 선물 준바하기</BtnSmallStroke>
     </S.EmptyViewWrapper>
   );
 };

--- a/src/pages/MyPage/Detail/EmptyView/EmptyView.tsx
+++ b/src/pages/MyPage/Detail/EmptyView/EmptyView.tsx
@@ -16,9 +16,11 @@ const EmptyView = ({ title }: EmptyViewType) => {
   return (
     <S.EmptyViewWrapper>
       <DetailHeader title={title} />
-      <IcLogoEmpty />
-      <S.Text>준비했던 선물이 없어요</S.Text>
-      <BtnSmallStroke onClick={handleClickButton}>새로운 선물 준바하기</BtnSmallStroke>
+      <IcLogoEmpty style={{ width: '8rem', height: '6.4rem' }} />
+      <S.EmptyText>준비했던 선물이 없어요</S.EmptyText>
+      <BtnSmallStroke onClick={handleClickButton} customStyle={{ margin: '1.6rem' }}>
+        새로운 선물 준바하기
+      </BtnSmallStroke>
     </S.EmptyViewWrapper>
   );
 };


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #499
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] empty 일때 선물방 생성으로 잘 이동하도록
- [x] empty view 공통 컴포넌트화 적용


## Need Review
- 선물방이 없을때 버튼 클릭 시 선물방 생성으로 이동하도록 하였습니다.
- 또한 empty view를 공동으로 구성하여 컴포넌트화 시켰습니다.
- 또한 issue 속에 있는 태그 위치를 수정하는 과정이 drop 된줄 알고 확인해 봤는데 로컬에선 잘 예쁘게 변경 되었고, 배포 페이지에서만 이상한걸 보니 아마 main 반영이 안 된거 같습니다 ! 해당 사항 배포페이지에 같이 적용해보도록 하겠습니다.
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->



## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
