### PR TITLE
[마이페이지] 하단에 카카오 광고 배너 삽입

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import { QueryClient, QueryClientProvider, QueryErrorResetBoundary } from '@tanstack/react-query';
 import { RouterProvider } from 'react-router-dom';
 import router from './router/Router';
-import GlobalStyle from './style/GlobalStyle';
 import Loading from './pages/Loading/Loading';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -25,7 +24,6 @@ function App() {
                 <RouterProvider router={router} />
                 <Analytics />
                 <SpeedInsights />
-                <GlobalStyle />
                 <StyledToastContainer
                   position='bottom-center'
                   autoClose={3000}

--- a/src/components/KakaoAd/KakaoAd.tsx
+++ b/src/components/KakaoAd/KakaoAd.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import KakaoAdCallback from './KakaoAdCallback';
 
 const KakaoAd = () => {
   const scriptElement = useRef<HTMLDivElement>(null);
@@ -23,6 +24,7 @@ const KakaoAd = () => {
           data-ad-unit='DAN-ZAZ2jcyFWckRtcrp'
           data-ad-width='320'
           data-ad-height='50'
+          data-ad-onfail={<KakaoAdCallback />}
         />
       </div>
     </>

--- a/src/components/KakaoAd/KakaoAd.tsx
+++ b/src/components/KakaoAd/KakaoAd.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+
+const KakaoAd = () => {
+  const scriptElement = useRef<HTMLDivElement>(null);
+
+  // script 태그를 동적으로 추가
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.setAttribute('src', 'https://t1.daumcdn.net/kas/static/ba.min.js');
+    script.setAttribute('charset', 'utf-8');
+
+    script.setAttribute('async', 'true');
+    scriptElement.current?.appendChild(script);
+  }, []);
+
+  return (
+    <>
+      ...
+      <div ref={scriptElement}>
+        <ins
+          className='kakao_ad_area'
+          style={{ display: 'none' }}
+          data-ad-unit='DAN-ZAZ2jcyFWckRtcrp'
+          data-ad-width='320'
+          data-ad-height='50'
+        />
+      </div>
+    </>
+  );
+};
+
+export default KakaoAd;

--- a/src/components/KakaoAd/KakaoAdCallback.style.ts
+++ b/src/components/KakaoAd/KakaoAdCallback.style.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const KakaoAdCallbackWrapper = styled.div`
+  ${({ theme }) => theme.mixin.flexCenter({})};
+  background-color: white;
+  width: 100%;
+  color: black;
+  ${({ theme: { fonts } }) => fonts.body_03};
+`;

--- a/src/components/KakaoAd/KakaoAdCallback.tsx
+++ b/src/components/KakaoAd/KakaoAdCallback.tsx
@@ -1,0 +1,7 @@
+import * as S from './KakaoAdCallback.style';
+
+const KakaoAdCallback = () => {
+  return <S.KakaoAdCallbackWrapper>광고가 생성 될 부분입니다.</S.KakaoAdCallbackWrapper>;
+};
+
+export default KakaoAdCallback;

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router';
 import { useState } from 'react';
 import DeleteModal from '../../components/common/Modal/DeleteModal';
 import { logOutInstance } from '../../apis/client';
+import KakaoAd from '../../components/KakaoAd/KakaoAd';
 interface MyPage {
   memberData: MyPageType;
 }
@@ -90,6 +91,7 @@ const MyPage = () => {
           </BtnFill>
         </S.ProfileWrapper>
         {renderGiftRoom()}
+        <KakaoAd />
       </S.MyPageWrapper>
     </>
   );


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #517 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] kakao ad 를 활용하여 카카오 광고 배너를 마이페이지 하단에 삽입하였습니다. 비즈니스 모델을 광고 시스템 적용을 시작으로 확장 시켜 나갈 계획입니다.

## Need Review
- useEffect 와 useRef를 활용하여 적용했습니다.
- 해당 부분이 마이페이지가 아닌 메인 화면에 위치 시키지 않은 이유는 디자인을 방해 할 거 같다라는 판단이 들어서 입니다.
- 추후 디자이너와 TL과 상의하여 광고 위치나, 배너 사이즈를 상의해봐도 좋을 거 같습니다.
- kakao ad 가 아닌 다른 광고들도 추후 붙여 나가면 좋을 거 같습니다.
- 해당 부분 이미지는 하단 스크린샷을 참고해주세요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->



## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

<img width="236" alt="image" src="https://github.com/SWEET-DEVELOPERS/sweet-client/assets/38005874/f3dc698d-ed4e-4f58-9f38-dbd8155e9181">


## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
https://velog.io/@yoonth95/React-kakao-Adfit-%EC%88%98%EC%9D%B5%ED%99%94-%EC%A0%81%EC%9A%A9
https://adfit.kakao.com/dashboard
